### PR TITLE
Add support for modularized project since Java 9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           java-version: ${{ matrix.java }}
 
       - name: Build with Apache Maven
-        run: mvn clean test
+        run: mvn clean package
 
       - name: Report code coverage
         run: |

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ You can create `Semver` object in number of ways.
 #### Using constructor
 
 ```java
-Semver version=new Semver("1.2.3-beta.4+sha899d8g79f87");
+Semver version = new Semver("1.2.3-beta.4+sha899d8g79f87");
 ```
 
 #### Using `Semver.parse()` method

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,18 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.2</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.semver4j</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>3.2.1</version>
                 <executions>


### PR DESCRIPTION
`maven-jar-plugin` used which generates module name in `MANIFEST.MF` file:

```
Manifest-Version: 1.0
Created-By: Maven JAR Plugin 3.2.2
Build-Jdk-Spec: 17
Automatic-Module-Name: org.semver4j  <--- module name

```

Resolves #34 