### PR TITLE
feat: SEM-48 add validation to protect int overflow

### DIFF
--- a/src/main/java/org/semver4j/internal/StrictParser.java
+++ b/src/main/java/org/semver4j/internal/StrictParser.java
@@ -9,7 +9,6 @@ import java.util.StringJoiner;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static java.lang.Integer.parseInt;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;

--- a/src/main/java/org/semver4j/internal/StrictParser.java
+++ b/src/main/java/org/semver4j/internal/StrictParser.java
@@ -2,6 +2,7 @@ package org.semver4j.internal;
 
 import org.semver4j.SemverException;
 
+import java.math.BigInteger;
 import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
@@ -17,6 +18,7 @@ import static org.semver4j.internal.Tokenizers.STRICT;
 
 public class StrictParser {
     private static final Pattern pattern = compile(STRICT);
+    private static final BigInteger maxInt = BigInteger.valueOf(Integer.MAX_VALUE);
 
     public Version parse(String version) {
         Matcher matcher = pattern.matcher(version);
@@ -32,6 +34,14 @@ public class StrictParser {
         List<String> build = convertToList(matcher.group(5));
 
         return new Version(major, minor, patch, preRelease, build);
+    }
+
+    private int parseInt(String maybeInt){
+        BigInteger secureNumber = new BigInteger(maybeInt);
+        if(maxInt.compareTo(secureNumber) < 0){
+            throw new SemverException(format("Value [%s] is too big.", maybeInt));
+        }
+        return secureNumber.intValueExact();
     }
 
     private List<String> convertToList(String toList) {

--- a/src/test/java/org/semver4j/internal/StrictParserTest.java
+++ b/src/test/java/org/semver4j/internal/StrictParserTest.java
@@ -132,7 +132,6 @@ class StrictParserTest {
                 arguments("9.8.7-whatever+meta+meta"),
                 arguments("99999999999999999999999.999999999999999999.99999999999999999----RC-SNAPSHOT.12.09.1--------------------------------..12"),
                 arguments("1.1.1.1")
-
         );
     }
 }

--- a/src/test/java/org/semver4j/internal/StrictParserTest.java
+++ b/src/test/java/org/semver4j/internal/StrictParserTest.java
@@ -1,5 +1,6 @@
 package org.semver4j.internal;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -77,6 +78,17 @@ class StrictParserTest {
                 .hasMessage(format("Version [%s] is not valid semver.", version));
     }
 
+    @Test
+    void shouldParseInvalidVersions() {
+        //given
+        StrictParser strictParser = new StrictParser();
+
+        //when/then
+        assertThatThrownBy(() -> strictParser.parse("99999999999999999999999.999999999999999999.99999999999999999"))
+                .isInstanceOf(SemverException.class)
+                .hasMessage(format("Value [%s] is too big.", "99999999999999999999999"));
+    }
+
     static Stream<Arguments> invalidStrictSemver() {
         return Stream.of(
                 arguments("1"),
@@ -120,6 +132,7 @@ class StrictParserTest {
                 arguments("9.8.7-whatever+meta+meta"),
                 arguments("99999999999999999999999.999999999999999999.99999999999999999----RC-SNAPSHOT.12.09.1--------------------------------..12"),
                 arguments("1.1.1.1")
+
         );
     }
 }


### PR DESCRIPTION
Add validation of version value. If it's to big to be int, then throws. Still thinking about proper support of very big ints without api breaking changes. 