### PR TITLE
Add forbiddenapis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           java-version: ${{ matrix.java }}
 
       - name: Build with Apache Maven
-        run: ./mvnw clean package
+        run: ./mvnw clean verify -Dgpg.skip
 
       - name: Run checkstyle
         uses: nikitasavinov/checkstyle-action@0.6.0

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,38 @@
                     <configLocation>config/checkstyle/checkstyle.xml</configLocation>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>de.thetaphi</groupId>
+                <artifactId>forbiddenapis</artifactId>
+                <version>3.4</version>
+                <configuration>
+                    <failOnViolation>true</failOnViolation>
+                    <!-- if the used Java version is too new, don't fail, just do nothing: -->
+                    <failOnUnsupportedJava>false</failOnUnsupportedJava>
+                    <!-- prevent failing if a module doesn't have all signature dependencies like commons-io -->
+                    <ignoreSignaturesOfMissingClasses>true</ignoreSignaturesOfMissingClasses>
+                    <bundledSignatures>
+                        <!--
+                          This will automatically choose the right
+                          signatures based on 'maven.compiler.target':
+                        -->
+                        <bundledSignature>jdk-unsafe</bundledSignature>
+                        <bundledSignature>jdk-deprecated</bundledSignature>
+                        <!-- disallow undocumented classes like sun.misc.Unsafe: -->
+                        <bundledSignature>jdk-non-portable</bundledSignature>
+                        <!-- don't allow unsafe reflective access: -->
+                        <bundledSignature>jdk-reflection</bundledSignature>
+                    </bundledSignatures>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                            <goal>testCheck</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/main/java/org/semver4j/Range.java
+++ b/src/main/java/org/semver4j/Range.java
@@ -1,5 +1,6 @@
 package org.semver4j;
 
+import java.util.Locale;
 import java.util.Objects;
 
 import static java.lang.String.format;
@@ -57,7 +58,7 @@ public class Range {
                 return version.isGreaterThanOrEqualTo(rangeVersion);
         }
 
-        throw new RuntimeException(format("Unknown RangeOperator: %s", rangeOperator));
+        throw new RuntimeException(format(Locale.ROOT, "Unknown RangeOperator: %s", rangeOperator));
     }
 
     @Override
@@ -131,7 +132,7 @@ public class Range {
             return stream(values())
                 .filter(rangeOperator -> rangeOperator.asString().equals(string))
                 .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException(format("Range operator for '%s' not found", string)));
+                .orElseThrow(() -> new IllegalArgumentException(format(Locale.ROOT, "Range operator for '%s' not found", string)));
         }
     }
 }

--- a/src/main/java/org/semver4j/internal/Coerce.java
+++ b/src/main/java/org/semver4j/internal/Coerce.java
@@ -1,5 +1,6 @@
 package org.semver4j.internal;
 
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -23,7 +24,7 @@ public class Coerce {
             group4 = group4 != null ? group4 : "0";
             group5 = group5 != null ? group5 : "0";
 
-            return format("%s.%s.%s", group3, group4, group5);
+            return format(Locale.ROOT, "%s.%s.%s", group3, group4, group5);
         }
 
         return null;

--- a/src/main/java/org/semver4j/internal/Modifier.java
+++ b/src/main/java/org/semver4j/internal/Modifier.java
@@ -3,6 +3,7 @@ package org.semver4j.internal;
 import org.semver4j.Semver;
 
 import java.util.List;
+import java.util.Locale;
 
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
@@ -23,12 +24,12 @@ public class Modifier {
             nextMajor = nextMajor + 1;
         }
 
-        String version = createFullVersion(format("%d.0.0", nextMajor), emptyList());
+        String version = createFullVersion(format(Locale.ROOT, "%d.0.0", nextMajor), emptyList());
         return new Semver(version);
     }
 
     public Semver withIncMajor(int number) {
-        String version = createFullVersion(format("%d.%d.%d", (this.version.getMajor() + number), this.version.getMinor(), this.version.getPatch()), this.version.getPreRelease());
+        String version = createFullVersion(format(Locale.ROOT, "%d.%d.%d", (this.version.getMajor() + number), this.version.getMinor(), this.version.getPatch()), this.version.getPreRelease());
         return new Semver(version);
     }
 
@@ -40,12 +41,12 @@ public class Modifier {
             nextMinor = nextMinor + 1;
         }
 
-        String version = createFullVersion(format("%d.%d.0", this.version.getMajor(), nextMinor), emptyList());
+        String version = createFullVersion(format(Locale.ROOT, "%d.%d.0", this.version.getMajor(), nextMinor), emptyList());
         return new Semver(version);
     }
 
     public Semver withIncMinor(int number) {
-        String version = createFullVersion(format("%d.%d.%d", this.version.getMajor(), (this.version.getMinor() + number), this.version.getPatch()), this.version.getPreRelease());
+        String version = createFullVersion(format(Locale.ROOT, "%d.%d.%d", this.version.getMajor(), (this.version.getMinor() + number), this.version.getPatch()), this.version.getPreRelease());
         return new Semver(version);
     }
 
@@ -57,41 +58,41 @@ public class Modifier {
             newPatch = newPatch + 1;
         }
 
-        String version = createFullVersion(format("%d.%d.%d", this.version.getMajor(), this.version.getMinor(), newPatch), emptyList());
+        String version = createFullVersion(format(Locale.ROOT, "%d.%d.%d", this.version.getMajor(), this.version.getMinor(), newPatch), emptyList());
         return new Semver(version);
     }
 
     public Semver withIncPatch(int number) {
-        String version = createFullVersion(format("%d.%d.%d", this.version.getMajor(), this.version.getMinor(), (this.version.getPatch() + number)), this.version.getPreRelease());
+        String version = createFullVersion(format(Locale.ROOT, "%d.%d.%d", this.version.getMajor(), this.version.getMinor(), (this.version.getPatch() + number)), this.version.getPreRelease());
         return new Semver(version);
     }
 
     public Semver withPreRelease(String preRelease) {
         List<String> newPreRelease = asList(preRelease.split("\\."));
 
-        String version = createFullVersion(format("%d.%d.%d", this.version.getMajor(), this.version.getMinor(), this.version.getPatch()), newPreRelease);
+        String version = createFullVersion(format(Locale.ROOT, "%d.%d.%d", this.version.getMajor(), this.version.getMinor(), this.version.getPatch()), newPreRelease);
         return new Semver(version);
     }
 
     public Semver withBuild(String build) {
         List<String> newBuild = asList(build.split("\\."));
 
-        String version = createFullVersion(format("%d.%d.%d", this.version.getMajor(), this.version.getMinor(), this.version.getPatch()), this.version.getPreRelease(), newBuild);
+        String version = createFullVersion(format(Locale.ROOT, "%d.%d.%d", this.version.getMajor(), this.version.getMinor(), this.version.getPatch()), this.version.getPreRelease(), newBuild);
         return new Semver(version);
     }
 
     public Semver withClearedPreRelease() {
-        String version = createFullVersion(format("%d.%d.%d", this.version.getMajor(), this.version.getMinor(), this.version.getPatch()), emptyList());
+        String version = createFullVersion(format(Locale.ROOT, "%d.%d.%d", this.version.getMajor(), this.version.getMinor(), this.version.getPatch()), emptyList());
         return new Semver(version);
     }
 
     public Semver withClearedBuild() {
-        String version = createFullVersion(format("%d.%d.%d", this.version.getMajor(), this.version.getMinor(), this.version.getPatch()), this.version.getPreRelease(), emptyList());
+        String version = createFullVersion(format(Locale.ROOT, "%d.%d.%d", this.version.getMajor(), this.version.getMinor(), this.version.getPatch()), this.version.getPreRelease(), emptyList());
         return new Semver(version);
     }
 
     public Semver withClearedPreReleaseAndBuild() {
-        String version = format("%d.%d.%d", this.version.getMajor(), this.version.getMinor(), this.version.getPatch());
+        String version = format(Locale.ROOT, "%d.%d.%d", this.version.getMajor(), this.version.getMinor(), this.version.getPatch());
         return new Semver(version);
     }
 

--- a/src/main/java/org/semver4j/internal/StrictParser.java
+++ b/src/main/java/org/semver4j/internal/StrictParser.java
@@ -4,6 +4,7 @@ import org.semver4j.SemverException;
 
 import java.math.BigInteger;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.StringJoiner;
 import java.util.regex.Matcher;
@@ -23,7 +24,7 @@ public class StrictParser {
         Matcher matcher = pattern.matcher(version);
 
         if (!matcher.matches()) {
-            throw new SemverException(format("Version [%s] is not valid semver.", version));
+            throw new SemverException(format(Locale.ROOT, "Version [%s] is not valid semver.", version));
         }
 
         int major = parseInt(matcher.group(1));
@@ -38,7 +39,7 @@ public class StrictParser {
     private int parseInt(String maybeInt) {
         BigInteger secureNumber = new BigInteger(maybeInt);
         if (maxInt.compareTo(secureNumber) < 0) {
-            throw new SemverException(format("Value [%s] is too big.", maybeInt));
+            throw new SemverException(format(Locale.ROOT, "Value [%s] is too big.", maybeInt));
         }
         return secureNumber.intValueExact();
     }

--- a/src/main/java/org/semver4j/internal/Tokenizers.java
+++ b/src/main/java/org/semver4j/internal/Tokenizers.java
@@ -2,6 +2,8 @@ package org.semver4j.internal;
 
 import static java.lang.String.format;
 
+import java.util.Locale;
+
 /**
  * List of regexp that helps with tokenizing and parsing <a href="https://semver.org">semver</a> strings.
  */
@@ -22,21 +24,21 @@ public class Tokenizers {
      * Dot separated numeric version identifiers (<b>MAJOR</b>.<b>MINOR</b>.<b>PATCH</b>).<br>
      * See <a href="https://semver.org/#summary">semver.org#summary</a>
      */
-    private static final String MAIN_VERSION = format("(%s)\\.(%s)\\.(%s)", NUMERIC_IDENTIFIER, NUMERIC_IDENTIFIER, NUMERIC_IDENTIFIER);
+    private static final String MAIN_VERSION = format(Locale.ROOT, "(%s)\\.(%s)\\.(%s)", NUMERIC_IDENTIFIER, NUMERIC_IDENTIFIER, NUMERIC_IDENTIFIER);
 
-    private static final String PRERELEASE_IDENTIFIER = format("(?:%s|%s)", NUMERIC_IDENTIFIER, NON_NUMERIC_IDENTIFIER);
+    private static final String PRERELEASE_IDENTIFIER = format(Locale.ROOT, "(?:%s|%s)", NUMERIC_IDENTIFIER, NON_NUMERIC_IDENTIFIER);
 
     /**
      * Prerelease identifier forwarded by hyphen with appended series of dot-separated identifiers.<br>
      * See <a href="https://semver.org/#spec-item-9">semver.org#spec-item-9</a>
      */
-    private static final String PRERELEASE = format("(?:-(%s(?:\\.%s)*))", PRERELEASE_IDENTIFIER, PRERELEASE_IDENTIFIER);
+    private static final String PRERELEASE = format(Locale.ROOT, "(?:-(%s(?:\\.%s)*))", PRERELEASE_IDENTIFIER, PRERELEASE_IDENTIFIER);
 
     private static final String BUILD_IDENTIFIER = "[0-9A-Za-z-]+";
 
-    private static final String BUILD = format("(?:\\+(%s(?:\\.%s)*))", BUILD_IDENTIFIER, BUILD_IDENTIFIER);
+    private static final String BUILD = format(Locale.ROOT, "(?:\\+(%s(?:\\.%s)*))", BUILD_IDENTIFIER, BUILD_IDENTIFIER);
 
-    private static final String STRICT_PLAIN = format("v?%s%s?%s?", MAIN_VERSION, PRERELEASE, BUILD);
+    private static final String STRICT_PLAIN = format(Locale.ROOT, "v?%s%s?%s?", MAIN_VERSION, PRERELEASE, BUILD);
 
     /**
      * Fully, completely valid semver value.<br>
@@ -50,31 +52,31 @@ public class Tokenizers {
      * X.Y.X-beta.1+sha1234
      * </code>
      */
-    public static final String STRICT = format("^%s$", STRICT_PLAIN);
+    public static final String STRICT = format(Locale.ROOT, "^%s$", STRICT_PLAIN);
 
     /**
      * <p>{@code x}, {@code X} and {@code *} are for X-Ranges.</p>
      * <p>{@code +} is for Ivy ranges.</p>
      */
-    private static final String XRANGE_IDENTIFIER = format("%s|x|X|\\*|\\+", NUMERIC_IDENTIFIER);
+    private static final String XRANGE_IDENTIFIER = format(Locale.ROOT, "%s|x|X|\\*|\\+", NUMERIC_IDENTIFIER);
 
-    private static final String XRANGE_PLAIN = format("[v=\\s]*(%s)(?:\\.(%s)(?:\\.(%s)(?:%s)?%s?)?)?", XRANGE_IDENTIFIER, XRANGE_IDENTIFIER, XRANGE_IDENTIFIER, PRERELEASE, BUILD);
+    private static final String XRANGE_PLAIN = format(Locale.ROOT, "[v=\\s]*(%s)(?:\\.(%s)(?:\\.(%s)(?:%s)?%s?)?)?", XRANGE_IDENTIFIER, XRANGE_IDENTIFIER, XRANGE_IDENTIFIER, PRERELEASE, BUILD);
 
     private static final String LONE_CARET = "(?:\\^)";
 
-    public static final String CARET = format("^%s%s$", LONE_CARET, XRANGE_PLAIN);
+    public static final String CARET = format(Locale.ROOT, "^%s%s$", LONE_CARET, XRANGE_PLAIN);
 
-    public static final String HYPHEN = format("^\\s*(%s)\\s+-\\s+(%s)\\s*$", XRANGE_PLAIN, XRANGE_PLAIN);
+    public static final String HYPHEN = format(Locale.ROOT, "^\\s*(%s)\\s+-\\s+(%s)\\s*$", XRANGE_PLAIN, XRANGE_PLAIN);
 
     public static final String IVY = "^(\\[|\\]|\\()([0-9]+)?\\.?([0-9]+)?\\,([0-9]+)?\\.?([0-9]+)?(\\]|\\[|\\))$";
 
-    public static final String TILDE = format("^(?:~>?)%s$", XRANGE_PLAIN);
+    public static final String TILDE = format(Locale.ROOT, "^(?:~>?)%s$", XRANGE_PLAIN);
 
     private static final String GLTL = "((?:<|>)?=?)";
 
-    public static final String XRANGE = format("^%s\\s*%s$", GLTL, XRANGE_PLAIN);
+    public static final String XRANGE = format(Locale.ROOT, "^%s\\s*%s$", GLTL, XRANGE_PLAIN);
 
-    public static final String COMPARATOR = format("^%s\\s*(%s)$|^$", GLTL, STRICT_PLAIN);
+    public static final String COMPARATOR = format(Locale.ROOT, "^%s\\s*(%s)$|^$", GLTL, STRICT_PLAIN);
 
     public static final String COERCE = "(^|[^\\d])(\\d{1,16})(?:\\.(\\d{1,16}))?(?:\\.(\\d{1,16}))?(?:$|[^\\d])";
 }

--- a/src/main/java/org/semver4j/internal/range/processor/CaretProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/CaretProcessor.java
@@ -1,5 +1,6 @@
 package org.semver4j.internal.range.processor;
 
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -48,44 +49,44 @@ public class CaretProcessor implements Processor {
         String to;
 
         if (minorIsX) {
-            from = format("%s%d.0.0", GTE.asString(), major);
-            to = format("%s%d.0.0", LT.asString(), (major + 1));
+            from = format(Locale.ROOT, "%s%d.0.0", GTE.asString(), major);
+            to = format(Locale.ROOT, "%s%d.0.0", LT.asString(), (major + 1));
         } else if (patchIsX) {
             if (major == 0) {
-                from = format("%s%d.%d.0", GTE.asString(), major, minor);
-                to = format("%s%d.%d.0", LT.asString(), major, (minor + 1));
+                from = format(Locale.ROOT, "%s%d.%d.0", GTE.asString(), major, minor);
+                to = format(Locale.ROOT, "%s%d.%d.0", LT.asString(), major, (minor + 1));
             } else {
-                from = format("%s%d.%d.0", GTE.asString(), major, minor);
-                to = format("%s%d.0.0", LT.asString(), (major + 1));
+                from = format(Locale.ROOT, "%s%d.%d.0", GTE.asString(), major, minor);
+                to = format(Locale.ROOT, "%s%d.0.0", LT.asString(), (major + 1));
             }
         } else if (isNotBlank(preRelease)) {
             if (major == 0) {
                 if (minor == 0) {
-                    from = format("%s%d.%d.%d-%s", GTE.asString(), major, minor, path, preRelease);
-                    to = format("%s%d.%d.%d", LT.asString(), major, minor, (path + 1));
+                    from = format(Locale.ROOT, "%s%d.%d.%d-%s", GTE.asString(), major, minor, path, preRelease);
+                    to = format(Locale.ROOT, "%s%d.%d.%d", LT.asString(), major, minor, (path + 1));
                 } else {
-                    from = format("%s%d.%d.%d-%s", GTE.asString(), major, minor, path, preRelease);
-                    to = format("%s%d.%d.0", LT.asString(), major, (minor + 1));
+                    from = format(Locale.ROOT, "%s%d.%d.%d-%s", GTE.asString(), major, minor, path, preRelease);
+                    to = format(Locale.ROOT, "%s%d.%d.0", LT.asString(), major, (minor + 1));
                 }
             } else {
-                from = format("%s%d.%d.%d-%s", GTE.asString(), major, minor, path, preRelease);
-                to = format("%s%d.0.0", LT.asString(), (major + 1));
+                from = format(Locale.ROOT, "%s%d.%d.%d-%s", GTE.asString(), major, minor, path, preRelease);
+                to = format(Locale.ROOT, "%s%d.0.0", LT.asString(), (major + 1));
             }
         } else {
             if (major == 0) {
                 if (minor == 0) {
-                    from = format("%s%d.%d.%d", GTE.asString(), major, minor, path);
-                    to = format("%s%d.%d.%d", LT.asString(), major, minor, (path + 1));
+                    from = format(Locale.ROOT, "%s%d.%d.%d", GTE.asString(), major, minor, path);
+                    to = format(Locale.ROOT, "%s%d.%d.%d", LT.asString(), major, minor, (path + 1));
                 } else {
-                    from = format("%s%d.%d.%d", GTE.asString(), major, minor, path);
-                    to = format("%s%d.%d.0", LT.asString(), major, (minor + 1));
+                    from = format(Locale.ROOT, "%s%d.%d.%d", GTE.asString(), major, minor, path);
+                    to = format(Locale.ROOT, "%s%d.%d.0", LT.asString(), major, (minor + 1));
                 }
             } else {
-                from = format("%s%d.%d.%d", GTE.asString(), major, minor, path);
-                to = format("%s%d.0.0", LT.asString(), (major + 1));
+                from = format(Locale.ROOT, "%s%d.%d.%d", GTE.asString(), major, minor, path);
+                to = format(Locale.ROOT, "%s%d.0.0", LT.asString(), (major + 1));
             }
         }
 
-        return format("%s %s", from, to);
+        return format(Locale.ROOT, "%s %s", from, to);
     }
 }

--- a/src/main/java/org/semver4j/internal/range/processor/GreaterThanOrEqualZeroProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/GreaterThanOrEqualZeroProcessor.java
@@ -3,6 +3,8 @@ package org.semver4j.internal.range.processor;
 import static java.lang.String.format;
 import static org.semver4j.Range.RangeOperator.GTE;
 
+import java.util.Locale;
+
 /**
  * <p>Processor for translate {@code latest}, {@code latest.internal} and {@code *} strings into classic range.</p>
  * <br>
@@ -15,7 +17,7 @@ public class GreaterThanOrEqualZeroProcessor implements Processor {
     @Override
     public String process(String range) {
         if (range.equals("latest") || range.equals("latest.integration") || range.equals("*") || range.isEmpty()) {
-            return format("%s0.0.0", GTE.asString());
+            return format(Locale.ROOT, "%s0.0.0", GTE.asString());
         }
         return range;
     }

--- a/src/main/java/org/semver4j/internal/range/processor/HyphenProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/HyphenProcessor.java
@@ -1,5 +1,6 @@
 package org.semver4j.internal.range.processor;
 
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -36,7 +37,7 @@ public class HyphenProcessor implements Processor {
         String rangeFrom = getRangeFrom(matcher);
         String rangeTo = getRangeTo(matcher);
 
-        return format("%s %s", rangeFrom, rangeTo);
+        return format(Locale.ROOT, "%s %s", rangeFrom, rangeTo);
     }
 
     private String getRangeFrom(Matcher matcher) {
@@ -54,12 +55,12 @@ public class HyphenProcessor implements Processor {
         boolean patchIsX = isX(fromPatch);
 
         if (minorIsX) {
-            return format("%s%d.0.0", GTE.asString(), fromMajor);
+            return format(Locale.ROOT, "%s%d.0.0", GTE.asString(), fromMajor);
         } else {
             if (patchIsX) {
-                return format("%s%d.%d.0", GTE.asString(), fromMajor, fromMinor);
+                return format(Locale.ROOT, "%s%d.%d.0", GTE.asString(), fromMajor, fromMinor);
             } else {
-                return format("%s%s", GTE.asString(), from);
+                return format(Locale.ROOT, "%s%s", GTE.asString(), from);
             }
         }
     }
@@ -79,12 +80,12 @@ public class HyphenProcessor implements Processor {
         boolean patchIsX = isX(toPatch);
 
         if (minorIsX) {
-            return format("%s%d.0.0", LT.asString(), (toMajor + 1));
+            return format(Locale.ROOT, "%s%d.0.0", LT.asString(), (toMajor + 1));
         } else {
             if (patchIsX) {
-                return format("%s%d.%d.0", LT.asString(), toMajor, (toMinor + 1));
+                return format(Locale.ROOT, "%s%d.%d.0", LT.asString(), toMajor, (toMinor + 1));
             } else {
-                return format("%s%s", LTE.asString(), to);
+                return format(Locale.ROOT, "%s%s", LTE.asString(), to);
             }
         }
     }

--- a/src/main/java/org/semver4j/internal/range/processor/IvyProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/IvyProcessor.java
@@ -1,5 +1,6 @@
 package org.semver4j.internal.range.processor;
 
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -62,25 +63,25 @@ public class IvyProcessor implements Processor {
         boolean closeInclusive = isInclusiveRange(closeSign);
         if (openInclusive && closeInclusive) {
             if (openSign.equals("[") && closeSign.equals("]")) {
-                return format("%s%d.%d.0 %s%d.%d.0", GTE.asString(), fromMajor, fromMinor, LTE.asString(), toMajor, toMinor);
+                return format(Locale.ROOT, "%s%d.%d.0 %s%d.%d.0", GTE.asString(), fromMajor, fromMinor, LTE.asString(), toMajor, toMinor);
             } else if (openSign.equals("[") && closeSign.equals("[")) {
-                return format("%s%d.%d.0 %s%d.%d.0", GTE.asString(), fromMajor, fromMinor, LT.asString(), toMajor, toMinor);
+                return format(Locale.ROOT, "%s%d.%d.0 %s%d.%d.0", GTE.asString(), fromMajor, fromMinor, LT.asString(), toMajor, toMinor);
             } else if (openSign.equals("]") && closeSign.equals("]")) {
-                return format("%s%d.%d.0 %s%d.%d.0", GT.asString(), fromMajor, fromMinor, LTE.asString(), toMajor, toMinor);
+                return format(Locale.ROOT, "%s%d.%d.0 %s%d.%d.0", GT.asString(), fromMajor, fromMinor, LTE.asString(), toMajor, toMinor);
             } else if (openSign.equals("]") && closeSign.equals("[")) {
-                return format("%s%d.%d.0 %s%d.%d.0", GT.asString(), fromMajor, fromMinor, LT.asString(), toMajor, toMinor);
+                return format(Locale.ROOT, "%s%d.%d.0 %s%d.%d.0", GT.asString(), fromMajor, fromMinor, LT.asString(), toMajor, toMinor);
             }
         } else if (closeSign.equals(")")) {
             if (openSign.equals("[")) {
-                return format("%s%d.%d.0", GTE.asString(), fromMajor, fromMinor);
+                return format(Locale.ROOT, "%s%d.%d.0", GTE.asString(), fromMajor, fromMinor);
             } else if (openSign.equals("]")) {
-                return format("%s%d.%d.0", GT.asString(), fromMajor, fromMinor);
+                return format(Locale.ROOT, "%s%d.%d.0", GT.asString(), fromMajor, fromMinor);
             }
         } else if (openSign.equals("(")) {
             if (closeSign.equals("]")) {
-                return format("%s%d.%d.0", LTE.asString(), toMajor, toMinor);
+                return format(Locale.ROOT, "%s%d.%d.0", LTE.asString(), toMajor, toMinor);
             } else if (closeSign.equals("[")) {
-                return format("%s%d.%d.0", LT.asString(), toMajor, toMinor);
+                return format(Locale.ROOT, "%s%d.%d.0", LT.asString(), toMajor, toMinor);
             }
         }
 

--- a/src/main/java/org/semver4j/internal/range/processor/TildeProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/TildeProcessor.java
@@ -1,5 +1,6 @@
 package org.semver4j.internal.range.processor;
 
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -49,19 +50,19 @@ public class TildeProcessor implements Processor {
         String to;
 
         if (isX(minor)) {
-            from = format("%s%d.0.0", GTE.asString(), major);
-            to = format("%s%d.0.0", LT.asString(), (major + 1));
+            from = format(Locale.ROOT, "%s%d.0.0", GTE.asString(), major);
+            to = format(Locale.ROOT, "%s%d.0.0", LT.asString(), (major + 1));
         } else if (isX(path)) {
-            from = format("%s%d.%d.0", GTE.asString(), major, minor);
-            to = format("%s%d.%d.0", LT.asString(), major, (minor + 1));
+            from = format(Locale.ROOT, "%s%d.%d.0", GTE.asString(), major, minor);
+            to = format(Locale.ROOT, "%s%d.%d.0", LT.asString(), major, (minor + 1));
         } else if (isNotBlank(preRelease)) {
-            from = format("%s%d.%d.%d-%s", GTE.asString(), major, minor, path, preRelease);
-            to = format("%s%d.%d.0", LT.asString(), major, (minor + 1));
+            from = format(Locale.ROOT, "%s%d.%d.%d-%s", GTE.asString(), major, minor, path, preRelease);
+            to = format(Locale.ROOT, "%s%d.%d.0", LT.asString(), major, (minor + 1));
         } else {
-            from = format("%s%d.%d.%d", GTE.asString(), major, minor, path);
-            to = format("%s%d.%d.0", LT.asString(), major, (minor + 1));
+            from = format(Locale.ROOT, "%s%d.%d.%d", GTE.asString(), major, minor, path);
+            to = format(Locale.ROOT, "%s%d.%d.0", LT.asString(), major, (minor + 1));
         }
 
-        return format("%s %s", from, to);
+        return format(Locale.ROOT, "%s %s", from, to);
     }
 }

--- a/src/main/java/org/semver4j/internal/range/processor/XRangeProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/XRangeProcessor.java
@@ -2,6 +2,7 @@ package org.semver4j.internal.range.processor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -68,16 +69,16 @@ public class XRangeProcessor implements Processor {
                         }
                     }
 
-                    String from = format("%s%d.%d.%d", compareSign, major, minor, patch);
+                    String from = format(Locale.ROOT, "%s%d.%d.%d", compareSign, major, minor, patch);
                     objects.add(from);
                 } else if (isX(minor)) {
-                    String from = format("%s%d.0.0", GTE.asString(), major);
-                    String to = format("%s%d.0.0", LT.asString(), (major + 1));
+                    String from = format(Locale.ROOT, "%s%d.0.0", GTE.asString(), major);
+                    String to = format(Locale.ROOT, "%s%d.0.0", LT.asString(), (major + 1));
                     objects.add(from);
                     objects.add(to);
                 } else if (isX(patch)) {
-                    String from = format("%s%d.%d.0", GTE.asString(), major, minor);
-                    String to = format("%s%d.%d.0", LT.asString(), major, (minor + 1));
+                    String from = format(Locale.ROOT, "%s%d.%d.0", GTE.asString(), major, minor);
+                    String to = format(Locale.ROOT, "%s%d.%d.0", LT.asString(), major, (minor + 1));
                     objects.add(from);
                     objects.add(to);
                 } else {

--- a/src/test/java/org/semver4j/SemverTest.java
+++ b/src/test/java/org/semver4j/SemverTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.semver4j.Semver.VersionDiff;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Stream;
 
 import static java.lang.String.format;
@@ -29,7 +30,7 @@ class SemverTest {
         //when/then
         assertThatThrownBy(() -> new Semver(version))
                 .isInstanceOf(SemverException.class)
-                .hasMessage(format("Version [%s] is not valid semver.", version));
+                .hasMessage(format(Locale.ROOT, "Version [%s] is not valid semver.", version));
     }
 
     @Test
@@ -758,13 +759,13 @@ class SemverTest {
                 arguments("v2", "2.0.0"),
                 arguments("v3.4 replaces v3.3.1", "3.4.0"),
                 arguments("4.6.3.9.2-alpha2", "4.6.3"),
-                arguments(format("%s.2", repeat("1", 17)), "2.0.0"),
-                arguments(format("%s.2.3", repeat("1", 17)), "2.3.0"),
-                arguments(format("1.%s.3", repeat("2", 17)), "1.0.0"),
-                arguments(format("1.2.%s", repeat("3", 17)), "1.2.0"),
-                arguments(format("%s.2.3.4", repeat("1", 17)), "2.3.4"),
-                arguments(format("1.%s.3.4", repeat("2", 17)), "1.0.0"),
-                arguments(format("1.2.%s.4", repeat("3", 17)), "1.2.0"),
+                arguments(format(Locale.ROOT, "%s.2", repeat("1", 17)), "2.0.0"),
+                arguments(format(Locale.ROOT, "%s.2.3", repeat("1", 17)), "2.3.0"),
+                arguments(format(Locale.ROOT, "1.%s.3", repeat("2", 17)), "1.0.0"),
+                arguments(format(Locale.ROOT, "1.2.%s", repeat("3", 17)), "1.2.0"),
+                arguments(format(Locale.ROOT, "%s.2.3.4", repeat("1", 17)), "2.3.4"),
+                arguments(format(Locale.ROOT, "1.%s.3.4", repeat("2", 17)), "1.0.0"),
+                arguments(format(Locale.ROOT, "1.2.%s.4", repeat("3", 17)), "1.2.0"),
                 arguments("10", "10.0.0")
         );
     }

--- a/src/test/java/org/semver4j/internal/StrictParserTest.java
+++ b/src/test/java/org/semver4j/internal/StrictParserTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.semver4j.SemverException;
 import org.semver4j.internal.StrictParser.Version;
 
+import java.util.Locale;
 import java.util.stream.Stream;
 
 import static java.lang.String.format;
@@ -75,7 +76,7 @@ class StrictParserTest {
         //when/then
         assertThatThrownBy(() -> strictParser.parse(version))
                 .isInstanceOf(SemverException.class)
-                .hasMessage(format("Version [%s] is not valid semver.", version));
+                .hasMessage(format(Locale.ROOT, "Version [%s] is not valid semver.", version));
     }
 
     @Test
@@ -86,7 +87,7 @@ class StrictParserTest {
         //when/then
         assertThatThrownBy(() -> strictParser.parse("99999999999999999999999.999999999999999999.99999999999999999"))
                 .isInstanceOf(SemverException.class)
-                .hasMessage(format("Value [%s] is too big.", "99999999999999999999999"));
+                .hasMessage(format(Locale.ROOT, "Value [%s] is too big.", "99999999999999999999999"));
     }
 
     static Stream<Arguments> invalidStrictSemver() {


### PR DESCRIPTION
Apache Solr started using semver4j (https://issues.apache.org/jira/browse/SOLR-15910) and noticed that under certain Java locales semver4j fails (https://issues.apache.org/jira/browse/SOLR-16467). Solr randomizes the locales to ensure that tests pass. This PR adds forbidden-apis (https://github.com/policeman-tools/forbidden-apis) which is a static build check for APIs that have issues. The changes in this PR use `Locale.ROOT` which will be the same everywhere. This makes sense since we just want simple strings for version comparison.