### PR TITLE
RangesList: Omit outer parentheses

### DIFF
--- a/src/main/java/org/semver4j/RangesList.java
+++ b/src/main/java/org/semver4j/RangesList.java
@@ -81,7 +81,8 @@ public class RangesList {
     public String toString() {
         return rangesList.stream()
             .map(RangesList::formatRanges)
-            .collect(joining(OR_JOINER));
+            .collect(joining(OR_JOINER))
+            .replaceAll("^\\(([^()]+)\\)$", "$1");
     }
 
     private static String formatRanges(List<Range> ranges) {

--- a/src/test/java/org/semver4j/RangesListTest.java
+++ b/src/test/java/org/semver4j/RangesListTest.java
@@ -13,4 +13,13 @@ public class RangesListTest {
         //when/then
         assertThat(rangesList.toString()).isEqualTo("<=2.6.8 or (>=3.0.0 and <=3.0.1)");
     }
+
+    @Test
+    void shouldOmitOuterParentheses() {
+        //given
+        RangesList rangesList = RangesListFactory.create(">=3.0.0 <=3.0.1");
+
+        //when/then
+        assertThat(rangesList.toString()).isEqualTo(">=3.0.0 and <=3.0.1");
+    }
 }


### PR DESCRIPTION
Simplify the string representation by omitting superfluous outer parentheses.