### PR TITLE
Document `coerce` returning `null` on invalid version

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,8 @@ translation from not-semver into semver.
 
 ```java
 Semver version = Semver.coerce("..1"); // it produces the same result as new Semver("1.0.0")
+Semver version = Semver.coerce("invalid"); // returns null, cannot coerce this version
 ```
-
-If the version is invalid, a `SemverException` will be thrown.
 
 ### Is the version stable?
 

--- a/src/test/java/org/semver4j/SemverTest.java
+++ b/src/test/java/org/semver4j/SemverTest.java
@@ -807,6 +807,18 @@ class SemverTest {
     }
 
     @Test
+    void shouldReturnNullWhenVersionHasInvalidString() {
+        //given
+        String invalid = "broken-version";
+
+        //when
+        Semver semver = coerce(invalid);
+
+        //then
+        assertThat(semver).isNull();
+    }
+
+    @Test
     void shouldCreateSemverWithHyphenInBuildSection() {
         //when
         Semver semver = new Semver("1.2.3+123-abc");


### PR DESCRIPTION
In the README:

> #### Using `Semver.coerce()` method
> 
> [...]
> 
> *If the version is invalid, a `SemverException` will be thrown.*

I believe this has changed, since running:

```java
Semver coerce = Semver.coerce("invalid");
```

produces `coerce == null`.

This PR matches the `coerce` example with the one from `parse`, and removes the mention to `SemverException`.