### PR TITLE
Using longs to parse identifiers instead of ints to avoid issues when parsing timestamp-sized values

### DIFF
--- a/src/main/java/org/semver4j/internal/Comparator.java
+++ b/src/main/java/org/semver4j/internal/Comparator.java
@@ -77,9 +77,9 @@ public class Comparator implements Comparable<Semver> {
 
     private int compareIdentifiers(@NotNull final String a, @NotNull final String b) {
         try {
-            int aAsInt = Integer.parseInt(a);
-            int bAsInt = Integer.parseInt(b);
-            return compareIdentifiers(aAsInt, bAsInt);
+            long aAsLong = Long.parseLong(a);
+            long bAsLong = Long.parseLong(b);
+            return compareIdentifiers(aAsLong, bAsLong);
         } catch (NumberFormatException e) {
             //ignore
         }
@@ -89,8 +89,8 @@ public class Comparator implements Comparable<Semver> {
             String[] tokenArr1 = a.split(digitsExtract);
             String[] tokenArr2 = b.split(digitsExtract);
             if (tokenArr1[0].equals(tokenArr2[0])) {
-                int digitA = Integer.parseInt(tokenArr1[1]);
-                int digitB = Integer.parseInt(tokenArr2[1]);
+                long digitA = Long.parseLong(tokenArr1[1]);
+                long digitB = Long.parseLong(tokenArr2[1]);
                 return compareIdentifiers(digitA, digitB);
             }
         }
@@ -104,8 +104,8 @@ public class Comparator implements Comparable<Semver> {
         return 0;
     }
 
-    private int compareIdentifiers(int a, int b) {
-        return Integer.compare(a, b);
+    private int compareIdentifiers(long a, long b) {
+        return Long.compare(a, b);
     }
 
     private boolean isBothContainsDigits(@NotNull final String a, @NotNull final String b) {

--- a/src/test/java/org/semver4j/SemverTest.java
+++ b/src/test/java/org/semver4j/SemverTest.java
@@ -487,6 +487,7 @@ class SemverTest {
                 arguments("1.0.0-rc11", "1.0.0-rc3", true),
                 arguments("1.0.0-beta11", "1.0.0-beta3", true),
                 arguments("1.0.0-rc.3.x-13", "1.0.0-rc.3.x-3", true),
+                arguments("1.24.1-A-20240111143214", "1.24.1-A-20240111143213", true),
 
                 arguments("1.0.0-alpha", "1.0.0-alpha.1", false),
                 arguments("1.0.0-alpha.1", "1.0.0-alpha.beta", false),
@@ -500,7 +501,8 @@ class SemverTest {
                 arguments("0.0.1", "5.0.0", false),
                 arguments("1.0.0-alpha.12.ab-c", "1.0.0-alpha.12.ab-c", false),
                 arguments("1.0.0-rc3", "1.0.0-rc11", false),
-                arguments("1.0.0-beta11", "1.0.0-rc3", false)
+                arguments("1.0.0-beta11", "1.0.0-rc3", false),
+                arguments("1.24.1-A-20240111143213", "1.24.1-A-20240111143214", false)
         );
     }
 


### PR DESCRIPTION
Fixes #208