### PR TITLE
Introduce a `Semver.Builder`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,9 @@ end_of_line = lf
 insert_final_newline = true
 indent_style = space
 indent_size = 4
+tab_width = 4
 trim_trailing_whitespace = true
+ij_continuation_indent_size = 8
 
-[*.{yml, yaml}]
+[*.{yml,yaml}]
 indent_size = 2

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ and [Ivy](https://ant.apache.org/ivy/history/latest-milestone/settings/version-m
         * [External](#external)
         * [Internal](#internal)
     * [Modifying the version](#modifying-the-version)
+    * [Builder](#builder)
 * [Contributing](#contributing)
 * [Thanks](#thanks)
 
@@ -212,9 +213,9 @@ If you want to check if a version satisfies a range, use the `satisfies()` metho
 The internal ranges builds ranges using fluent interface.
 
 ```java
-RangesExpression rangesExpression=equal("1.0.0")
-    .and(less("2.0.0"))
-    .or(greaterOrEqual("3.0.0")); // (=1.0.0 and <2.0.0) or >=3.0.0
+RangesExpression rangesExpression = equal("1.0.0")
+        .and(less("2.0.0"))
+        .or(greaterOrEqual("3.0.0")); // (=1.0.0 and <2.0.0) or >=3.0.0
 ```
 
 ### Modifying the version
@@ -232,6 +233,26 @@ You can also use built-in versioning methods such as:
 - `nextMajor()`: `1.2.3-beta.4+sha32iddfu987 => 2.0.0`
 - `nextMinor()`: `1.2.3-beta.4+sha32iddfu987 => 1.3.0`
 - `nextPatch()`: `1.2.3-beta.4+sha32iddfu987 => 1.2.4`
+
+### Builder
+
+`Semver4j` provides an API for programmatically creating `Semver` object.
+
+The newly introduced API looks like:
+
+```java
+Semver semver = Semver.of()
+        .withMajor(1)
+        .withMinor(2)
+        .withBuild("5bb76cdb")
+        .toSemver();
+```
+
+And is an equivalent of:
+
+```java
+Semver semver = new Semver("1.2.0+5bb76cdb");
+```
 
 ## Contributing
 

--- a/src/test/java/org/semver4j/SemverTest.java
+++ b/src/test/java/org/semver4j/SemverTest.java
@@ -451,14 +451,14 @@ class SemverTest {
 
     static Stream<Arguments> apiCompatible() {
         return Stream.of(
-            arguments("0.4.3", false),
-            arguments("1.1.9", true),
-            arguments("1.2.0", true),
-            arguments("1.2.3", true),
-            arguments("1.2.4", true),
-            arguments("1.4.2", true),
-            arguments("2.0.0", false),
-            arguments("2.2.3", false)
+                arguments("0.4.3", false),
+                arguments("1.1.9", true),
+                arguments("1.2.0", true),
+                arguments("1.2.3", true),
+                arguments("1.2.4", true),
+                arguments("1.4.2", true),
+                arguments("2.0.0", false),
+                arguments("2.2.3", false)
         );
     }
 
@@ -1200,7 +1200,7 @@ class SemverTest {
         Semver semver = new Semver("1.1.1");
 
         RangesExpression expression = RangesExpression.less("1.0.0")
-            .or(RangesExpression.greater("10.0.1").or(RangesExpression.equal("1.1.1")));
+                .or(RangesExpression.greater("10.0.1").or(RangesExpression.equal("1.1.1")));
 
         //when
         boolean satisfies = semver.satisfies(expression);
@@ -1211,5 +1211,17 @@ class SemverTest {
 
     private static String repeat(String s, int n) {
         return join("", nCopies(n, s));
+    }
+
+    @Test
+    void shouldBuildDefaultSemverUsingBuilder() {
+        //given
+        Semver.Builder builder = new Semver.Builder();
+
+        //when
+        Semver semver = builder.toSemver();
+
+        //then
+        assertThat(semver.getVersion()).isEqualTo("0.0.0");
     }
 }


### PR DESCRIPTION
This PR introduces a `Semver.Builder` which helps with programmatically creating Semver objects.

The newly introduced API looks like:

```java
Semver semver = Semver.of()
        .withMajor(1)
        .withMinor(2)
        .withBuild("5bb76cdb")
        .toSemver();
```

And is an equivalent of:

```java
Semver semver = new Semver("1.2.0+5bb76cdb");
```