### PR TITLE
Conversion of internal package classes to use static only

### DIFF
--- a/src/main/java/org/semver4j/Semver.java
+++ b/src/main/java/org/semver4j/Semver.java
@@ -39,7 +39,7 @@ public class Semver implements Comparable<Semver> {
     public Semver(@NotNull final String version) {
         this.originalVersion = version.trim();
 
-        Version parsedVersion = new StrictParser().parse(this.originalVersion);
+        Version parsedVersion = StrictParser.parse(this.originalVersion);
 
         major = parsedVersion.getMajor();
         minor = parsedVersion.getMinor();
@@ -194,7 +194,7 @@ public class Semver implements Comparable<Semver> {
      */
     @NotNull
     public Semver nextMajor() {
-        return new Modifier(this).nextMajor();
+        return Modifier.nextMajor(this);
     }
 
     /**
@@ -215,7 +215,7 @@ public class Semver implements Comparable<Semver> {
      */
     @NotNull
     public Semver withIncMajor(int number) {
-        return new Modifier(this).withIncMajor(number);
+        return Modifier.withIncMajor(this, number);
     }
 
     /**
@@ -225,7 +225,7 @@ public class Semver implements Comparable<Semver> {
      */
     @NotNull
     public Semver nextMinor() {
-        return new Modifier(this).nextMinor();
+        return Modifier.nextMinor(this);
     }
 
     /**
@@ -246,7 +246,7 @@ public class Semver implements Comparable<Semver> {
      */
     @NotNull
     public Semver withIncMinor(int number) {
-        return new Modifier(this).withIncMinor(number);
+        return Modifier.withIncMinor(this, number);
     }
 
     /**
@@ -256,7 +256,7 @@ public class Semver implements Comparable<Semver> {
      */
     @NotNull
     public Semver nextPatch() {
-        return new Modifier(this).nextPatch();
+        return Modifier.nextPatch(this);
     }
 
     /**
@@ -277,7 +277,7 @@ public class Semver implements Comparable<Semver> {
      */
     @NotNull
     public Semver withIncPatch(int number) {
-        return new Modifier(this).withIncPatch(number);
+        return Modifier.withIncPatch(this, number);
     }
 
     /**
@@ -288,7 +288,7 @@ public class Semver implements Comparable<Semver> {
      */
     @NotNull
     public Semver withPreRelease(@NotNull final String preRelease) {
-        return new Modifier(this).withPreRelease(preRelease);
+        return Modifier.withPreRelease(this, preRelease);
     }
 
     /**
@@ -299,7 +299,7 @@ public class Semver implements Comparable<Semver> {
      */
     @NotNull
     public Semver withBuild(@NotNull final String build) {
-        return new Modifier(this).withBuild(build);
+        return Modifier.withBuild(this, build);
     }
 
     /**
@@ -309,7 +309,7 @@ public class Semver implements Comparable<Semver> {
      */
     @NotNull
     public Semver withClearedPreRelease() {
-        return new Modifier(this).withClearedPreRelease();
+        return Modifier.withClearedPreRelease(this);
     }
 
     /**
@@ -319,7 +319,7 @@ public class Semver implements Comparable<Semver> {
      */
     @NotNull
     public Semver withClearedBuild() {
-        return new Modifier(this).withClearedBuild();
+        return Modifier.withClearedBuild(this);
     }
 
     /**
@@ -329,12 +329,12 @@ public class Semver implements Comparable<Semver> {
      */
     @NotNull
     public Semver withClearedPreReleaseAndBuild() {
-        return new Modifier(this).withClearedPreReleaseAndBuild();
+        return Modifier.withClearedPreReleaseAndBuild(this);
     }
 
     @Override
     public int compareTo(@NotNull final Semver other) {
-        return new Comparator(this).compareTo(other);
+        return Comparator.compareTo(this, other);
     }
 
     /**
@@ -347,6 +347,7 @@ public class Semver implements Comparable<Semver> {
     /**
      * Checks whether the given version is API compatible with this version.
      */
+    @SuppressWarnings("unused")
     public boolean isApiCompatible(@NotNull final Semver version) {
         return diff(version).ordinal() < VersionDiff.MAJOR.ordinal();
     }
@@ -508,7 +509,7 @@ public class Semver implements Comparable<Semver> {
      */
     @NotNull
     public VersionDiff diff(@NotNull final Semver version) {
-        return new Differ(this).diff(version);
+        return Differ.diff(this, version);
     }
 
     /**
@@ -614,6 +615,7 @@ public class Semver implements Comparable<Semver> {
             return this;
         }
 
+        @SuppressWarnings("unused")
         public Builder withPreRelease(@NotNull String preRelease) {
             requireNonNull(preRelease, "preRelease cannot be null");
             return withPreReleases(new String[]{preRelease});
@@ -631,6 +633,7 @@ public class Semver implements Comparable<Semver> {
             return this;
         }
 
+        @SuppressWarnings("unused")
         public Builder withBuild(@NotNull String build) {
             requireNonNull(build, "build cannot be null");
             return withBuilds(new String[]{build});

--- a/src/main/java/org/semver4j/internal/Coerce.java
+++ b/src/main/java/org/semver4j/internal/Coerce.java
@@ -25,11 +25,11 @@ public class Coerce {
         Matcher matcher = PATTERN.matcher(version);
 
         if (matcher.find()) {
-            String group3 = matcher.group(2);
-            String group4 = Optional.ofNullable(matcher.group(3)).orElse("0");
-            String group5 = Optional.ofNullable(matcher.group(4)).orElse("0");
+            String coercedMajor = matcher.group(2);
+            String coercedMinor = Optional.ofNullable(matcher.group(3)).orElse("0");
+            String coercedPath = Optional.ofNullable(matcher.group(4)).orElse("0");
 
-            return format(Locale.ROOT, "%s.%s.%s", group3, group4, group5);
+            return format(Locale.ROOT, "%s.%s.%s", coercedMajor, coercedMinor, coercedPath);
         }
 
         return null;

--- a/src/main/java/org/semver4j/internal/Coerce.java
+++ b/src/main/java/org/semver4j/internal/Coerce.java
@@ -4,30 +4,30 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Locale;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static java.lang.String.format;
 import static java.util.regex.Pattern.compile;
-import static org.semver4j.internal.Tokenizers.COERCE;
 
 public class Coerce {
     @NotNull
-    private static final Pattern pattern = compile(COERCE);
+    private static final Pattern PATTERN = compile(
+        "(^|\\D)(\\d{1,16})(?:\\.(\\d{1,16}))?(?:\\.(\\d{1,16}))?(?:$|\\D)"
+    );
+
+    private Coerce() {
+    }
 
     @Nullable
     public static String coerce(@NotNull final String version) {
-        Matcher matcher = pattern.matcher(version);
+        Matcher matcher = PATTERN.matcher(version);
 
         if (matcher.find()) {
-            String group1 = matcher.group(0);
-            String group2 = matcher.group(1);
             String group3 = matcher.group(2);
-            String group4 = matcher.group(3);
-            String group5 = matcher.group(4);
-
-            group4 = group4 != null ? group4 : "0";
-            group5 = group5 != null ? group5 : "0";
+            String group4 = Optional.ofNullable(matcher.group(3)).orElse("0");
+            String group5 = Optional.ofNullable(matcher.group(4)).orElse("0");
 
             return format(Locale.ROOT, "%s.%s.%s", group3, group4, group5);
         }

--- a/src/main/java/org/semver4j/internal/Comparator.java
+++ b/src/main/java/org/semver4j/internal/Comparator.java
@@ -7,27 +7,22 @@ import java.util.List;
 
 import static java.lang.Math.max;
 
-public class Comparator implements Comparable<Semver> {
+public class Comparator {
     @NotNull
     private static final String UNDEFINED_MARKER = "undef";
 
-    @NotNull
-    private final Semver version;
-
-    public Comparator(@NotNull final Semver version) {
-        this.version = version;
+    private Comparator() {
     }
 
-    @Override
-    public int compareTo(@NotNull final Semver other) {
-        int result = mainCompare(other);
+    public static int compareTo(@NotNull final Semver version, @NotNull final Semver other) {
+        int result = mainCompare(version, other);
         if (result == 0) {
-            return preReleaseCompare(other);
+            return preReleaseCompare(version, other);
         }
         return result;
     }
 
-    private int mainCompare(@NotNull final Semver other) {
+    private static int mainCompare(@NotNull final Semver version, @NotNull final Semver other) {
         int majorCompare = compareIdentifiers(version.getMajor(), other.getMajor());
         if (majorCompare == 0) {
             int minorCompare = compareIdentifiers(version.getMinor(), other.getMinor());
@@ -41,7 +36,7 @@ public class Comparator implements Comparable<Semver> {
         }
     }
 
-    private int preReleaseCompare(@NotNull final Semver other) {
+    private static int preReleaseCompare(@NotNull final Semver version, @NotNull final Semver other) {
         if (!version.getPreRelease().isEmpty() && other.getPreRelease().isEmpty()) {
             return -1;
         } else if (version.getPreRelease().isEmpty() && !other.getPreRelease().isEmpty()) {
@@ -75,7 +70,7 @@ public class Comparator implements Comparable<Semver> {
         return 0;
     }
 
-    private int compareIdentifiers(@NotNull final String a, @NotNull final String b) {
+    private static int compareIdentifiers(@NotNull final String a, @NotNull final String b) {
         try {
             long aAsLong = Long.parseLong(a);
             long bAsLong = Long.parseLong(b);
@@ -104,16 +99,16 @@ public class Comparator implements Comparable<Semver> {
         return 0;
     }
 
-    private int compareIdentifiers(long a, long b) {
+    private static int compareIdentifiers(long a, long b) {
         return Long.compare(a, b);
     }
 
-    private boolean isBothContainsDigits(@NotNull final String a, @NotNull final String b) {
+    private static boolean isBothContainsDigits(@NotNull final String a, @NotNull final String b) {
         return a.matches(".*\\d.*") && b.matches(".*\\d.*");
     }
 
     @NotNull
-    private String getString(final int i, @NotNull final List<@NotNull String> list) {
+    private static String getString(final int i, @NotNull final List<@NotNull String> list) {
         try {
             return list.get(i);
         } catch (IndexOutOfBoundsException e) {

--- a/src/main/java/org/semver4j/internal/Differ.java
+++ b/src/main/java/org/semver4j/internal/Differ.java
@@ -7,15 +7,11 @@ import org.semver4j.Semver.VersionDiff;
 import static org.semver4j.Semver.VersionDiff.*;
 
 public class Differ {
-    @NotNull
-    private final Semver version;
-
-    public Differ(@NotNull final Semver version) {
-        this.version = version;
+    private Differ() {
     }
 
     @NotNull
-    public VersionDiff diff(@NotNull final Semver other) {
+    public static VersionDiff diff(@NotNull final Semver version, @NotNull final Semver other) {
         if (version.getMajor() != other.getMajor()) {
             return MAJOR;
         }

--- a/src/main/java/org/semver4j/internal/Modifier.java
+++ b/src/main/java/org/semver4j/internal/Modifier.java
@@ -11,15 +11,15 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 
 public class Modifier {
-    @NotNull
-    private final Semver version;
+    private static final String FULL_FORMAT = "%d.%d.%d";
+    private static final String MAJOR_FORMAT = "%d.0.0";
+    private static final String MAJOR_MINOR_FORMAT = "%d.%d.0";
 
-    public Modifier(@NotNull final Semver version) {
-        this.version = version;
+    private Modifier() {
     }
 
     @NotNull
-    public Semver nextMajor() {
+    public static Semver nextMajor(@NotNull final Semver version) {
         int nextMajor = version.getMajor();
 
         // Prerelease version 1.0.0-5 bumps to 1.0.0
@@ -27,18 +27,27 @@ public class Modifier {
             nextMajor = nextMajor + 1;
         }
 
-        String version = createFullVersion(format(Locale.ROOT, "%d.0.0", nextMajor), emptyList());
-        return new Semver(version);
+        return new Semver(createFullVersion(version, format(Locale.ROOT, MAJOR_FORMAT, nextMajor), emptyList()));
     }
 
     @NotNull
-    public Semver withIncMajor(int number) {
-        String version = createFullVersion(format(Locale.ROOT, "%d.%d.%d", (this.version.getMajor() + number), this.version.getMinor(), this.version.getPatch()), this.version.getPreRelease());
-        return new Semver(version);
+    public static Semver withIncMajor(@NotNull final Semver version, int number) {
+        return new Semver(
+                createFullVersion(
+                        version,
+                        format(
+                                Locale.ROOT,
+                                FULL_FORMAT,
+                                (version.getMajor() + number),
+                                version.getMinor(),
+                                version.getPatch()
+                        ),
+                        version.getPreRelease())
+        );
     }
 
     @NotNull
-    public Semver nextMinor() {
+    public static Semver nextMinor(@NotNull final Semver version) {
         int nextMinor = version.getMinor();
 
         // Prerelease version 1.2.0-5 bumps to 1.2.0
@@ -46,18 +55,34 @@ public class Modifier {
             nextMinor = nextMinor + 1;
         }
 
-        String version = createFullVersion(format(Locale.ROOT, "%d.%d.0", this.version.getMajor(), nextMinor), emptyList());
-        return new Semver(version);
+        return new Semver(
+                createFullVersion(
+                        version,
+                        format(Locale.ROOT, MAJOR_MINOR_FORMAT, version.getMajor(), nextMinor),
+                        emptyList()
+                )
+        );
     }
 
     @NotNull
-    public Semver withIncMinor(int number) {
-        String version = createFullVersion(format(Locale.ROOT, "%d.%d.%d", this.version.getMajor(), (this.version.getMinor() + number), this.version.getPatch()), this.version.getPreRelease());
-        return new Semver(version);
+    public static Semver withIncMinor(@NotNull final Semver version, int number) {
+        return new Semver(
+                createFullVersion(
+                        version,
+                        format(
+                                Locale.ROOT,
+                                FULL_FORMAT,
+                                version.getMajor(),
+                                (version.getMinor() + number),
+                                version.getPatch()
+                        ),
+                        version.getPreRelease()
+                )
+        );
     }
 
     @NotNull
-    public Semver nextPatch() {
+    public static Semver nextPatch(@NotNull final Semver version) {
         int newPatch = version.getPatch();
 
         // Prerelease version 1.2.0-5 bumps to 1.2.0
@@ -65,57 +90,100 @@ public class Modifier {
             newPatch = newPatch + 1;
         }
 
-        String version = createFullVersion(format(Locale.ROOT, "%d.%d.%d", this.version.getMajor(), this.version.getMinor(), newPatch), emptyList());
-        return new Semver(version);
+        return new Semver(
+                createFullVersion(
+                        version,
+                        format(Locale.ROOT, FULL_FORMAT, version.getMajor(), version.getMinor(), newPatch),
+                        emptyList()
+                )
+        );
     }
 
     @NotNull
-    public Semver withIncPatch(int number) {
-        String version = createFullVersion(format(Locale.ROOT, "%d.%d.%d", this.version.getMajor(), this.version.getMinor(), (this.version.getPatch() + number)), this.version.getPreRelease());
-        return new Semver(version);
+    public static Semver withIncPatch(@NotNull final Semver version, int number) {
+        return new Semver(
+                createFullVersion(
+                        version,
+                        format(
+                                Locale.ROOT,
+                                FULL_FORMAT,
+                                version.getMajor(),
+                                version.getMinor(),
+                                (version.getPatch() + number)
+                        ),
+                        version.getPreRelease()
+                )
+        );
     }
 
     @NotNull
-    public Semver withPreRelease(@NotNull final String preRelease) {
+    public static Semver withPreRelease(@NotNull final Semver version, @NotNull final String preRelease) {
         List<String> newPreRelease = asList(preRelease.split("\\."));
 
-        String version = createFullVersion(format(Locale.ROOT, "%d.%d.%d", this.version.getMajor(), this.version.getMinor(), this.version.getPatch()), newPreRelease);
-        return new Semver(version);
+        return new Semver(
+                createFullVersion(
+                        version,
+                        format(Locale.ROOT, FULL_FORMAT, version.getMajor(), version.getMinor(), version.getPatch()),
+                        newPreRelease
+                )
+        );
     }
 
     @NotNull
-    public Semver withBuild(@NotNull final String build) {
+    public static Semver withBuild(@NotNull final Semver version, @NotNull final String build) {
         List<String> newBuild = asList(build.split("\\."));
 
-        String version = createFullVersion(format(Locale.ROOT, "%d.%d.%d", this.version.getMajor(), this.version.getMinor(), this.version.getPatch()), this.version.getPreRelease(), newBuild);
-        return new Semver(version);
+        return new Semver(
+                createFullVersion(
+                        format(Locale.ROOT, FULL_FORMAT, version.getMajor(), version.getMinor(), version.getPatch()),
+                        version.getPreRelease(),
+                        newBuild
+                )
+        );
     }
 
     @NotNull
-    public Semver withClearedPreRelease() {
-        String version = createFullVersion(format(Locale.ROOT, "%d.%d.%d", this.version.getMajor(), this.version.getMinor(), this.version.getPatch()), emptyList());
-        return new Semver(version);
+    public static Semver withClearedPreRelease(@NotNull final Semver version) {
+        return new Semver(
+                createFullVersion(
+                        version,
+                        format(Locale.ROOT, FULL_FORMAT, version.getMajor(), version.getMinor(), version.getPatch()),
+                        emptyList()
+                )
+        );
     }
 
     @NotNull
-    public Semver withClearedBuild() {
-        String version = createFullVersion(format(Locale.ROOT, "%d.%d.%d", this.version.getMajor(), this.version.getMinor(), this.version.getPatch()), this.version.getPreRelease(), emptyList());
-        return new Semver(version);
+    public static Semver withClearedBuild(@NotNull final Semver version) {
+        return new Semver(
+                createFullVersion(
+                        format(Locale.ROOT, FULL_FORMAT, version.getMajor(), version.getMinor(), version.getPatch()),
+                        version.getPreRelease(),
+                        emptyList()
+                )
+        );
     }
 
     @NotNull
-    public Semver withClearedPreReleaseAndBuild() {
-        String version = format(Locale.ROOT, "%d.%d.%d", this.version.getMajor(), this.version.getMinor(), this.version.getPatch());
-        return new Semver(version);
+    public static Semver withClearedPreReleaseAndBuild(@NotNull final Semver version) {
+        return new Semver(format(Locale.ROOT, FULL_FORMAT, version.getMajor(), version.getMinor(), version.getPatch()));
     }
 
     @NotNull
-    private String createFullVersion(@NotNull final String main, @NotNull final List<@NotNull String> preRelease) {
+    private static String createFullVersion(
+            @NotNull final Semver version,
+            @NotNull final String main,
+            @NotNull final List<@NotNull String> preRelease
+    ) {
         return createFullVersion(main, preRelease, version.getBuild());
     }
 
     @NotNull
-    private String createFullVersion(@NotNull final String main, @NotNull final List<@NotNull String> preRelease, @NotNull final List<@NotNull String> build) {
+    private static String createFullVersion(
+            @NotNull final String main,
+            @NotNull final List<@NotNull String> preRelease,
+            @NotNull final List<@NotNull String> build
+    ) {
         StringBuilder stringBuilder = new StringBuilder(main);
 
         if (!preRelease.isEmpty()) {

--- a/src/main/java/org/semver4j/internal/Modifier.java
+++ b/src/main/java/org/semver4j/internal/Modifier.java
@@ -11,9 +11,6 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 
 public class Modifier {
-    private static final String FULL_FORMAT = "%d.%d.%d";
-    private static final String MAJOR_FORMAT = "%d.0.0";
-    private static final String MAJOR_MINOR_FORMAT = "%d.%d.0";
 
     private Modifier() {
     }
@@ -27,7 +24,7 @@ public class Modifier {
             nextMajor = nextMajor + 1;
         }
 
-        return new Semver(createFullVersion(version, format(Locale.ROOT, MAJOR_FORMAT, nextMajor), emptyList()));
+        return new Semver(createFullVersion(version, format(Locale.ROOT, "%d.0.0", nextMajor), emptyList()));
     }
 
     @NotNull
@@ -37,7 +34,7 @@ public class Modifier {
                         version,
                         format(
                                 Locale.ROOT,
-                                FULL_FORMAT,
+                                "%d.%d.%d",
                                 (version.getMajor() + number),
                                 version.getMinor(),
                                 version.getPatch()
@@ -58,7 +55,7 @@ public class Modifier {
         return new Semver(
                 createFullVersion(
                         version,
-                        format(Locale.ROOT, MAJOR_MINOR_FORMAT, version.getMajor(), nextMinor),
+                        format(Locale.ROOT, "%d.%d.0", version.getMajor(), nextMinor),
                         emptyList()
                 )
         );
@@ -71,7 +68,7 @@ public class Modifier {
                         version,
                         format(
                                 Locale.ROOT,
-                                FULL_FORMAT,
+                                "%d.%d.%d",
                                 version.getMajor(),
                                 (version.getMinor() + number),
                                 version.getPatch()
@@ -93,7 +90,7 @@ public class Modifier {
         return new Semver(
                 createFullVersion(
                         version,
-                        format(Locale.ROOT, FULL_FORMAT, version.getMajor(), version.getMinor(), newPatch),
+                        format(Locale.ROOT, "%d.%d.%d", version.getMajor(), version.getMinor(), newPatch),
                         emptyList()
                 )
         );
@@ -106,7 +103,7 @@ public class Modifier {
                         version,
                         format(
                                 Locale.ROOT,
-                                FULL_FORMAT,
+                                "%d.%d.%d",
                                 version.getMajor(),
                                 version.getMinor(),
                                 (version.getPatch() + number)
@@ -123,7 +120,7 @@ public class Modifier {
         return new Semver(
                 createFullVersion(
                         version,
-                        format(Locale.ROOT, FULL_FORMAT, version.getMajor(), version.getMinor(), version.getPatch()),
+                        format(Locale.ROOT, "%d.%d.%d", version.getMajor(), version.getMinor(), version.getPatch()),
                         newPreRelease
                 )
         );
@@ -135,7 +132,7 @@ public class Modifier {
 
         return new Semver(
                 createFullVersion(
-                        format(Locale.ROOT, FULL_FORMAT, version.getMajor(), version.getMinor(), version.getPatch()),
+                        format(Locale.ROOT, "%d.%d.%d", version.getMajor(), version.getMinor(), version.getPatch()),
                         version.getPreRelease(),
                         newBuild
                 )
@@ -147,7 +144,7 @@ public class Modifier {
         return new Semver(
                 createFullVersion(
                         version,
-                        format(Locale.ROOT, FULL_FORMAT, version.getMajor(), version.getMinor(), version.getPatch()),
+                        format(Locale.ROOT, "%d.%d.%d", version.getMajor(), version.getMinor(), version.getPatch()),
                         emptyList()
                 )
         );
@@ -157,7 +154,7 @@ public class Modifier {
     public static Semver withClearedBuild(@NotNull final Semver version) {
         return new Semver(
                 createFullVersion(
-                        format(Locale.ROOT, FULL_FORMAT, version.getMajor(), version.getMinor(), version.getPatch()),
+                        format(Locale.ROOT, "%d.%d.%d", version.getMajor(), version.getMinor(), version.getPatch()),
                         version.getPreRelease(),
                         emptyList()
                 )
@@ -166,7 +163,7 @@ public class Modifier {
 
     @NotNull
     public static Semver withClearedPreReleaseAndBuild(@NotNull final Semver version) {
-        return new Semver(format(Locale.ROOT, FULL_FORMAT, version.getMajor(), version.getMinor(), version.getPatch()));
+        return new Semver(format(Locale.ROOT, "%d.%d.%d", version.getMajor(), version.getMinor(), version.getPatch()));
     }
 
     @NotNull

--- a/src/main/java/org/semver4j/internal/Modifier.java
+++ b/src/main/java/org/semver4j/internal/Modifier.java
@@ -11,6 +11,9 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 
 public class Modifier {
+    private static final String FULL_FORMAT = "%d.%d.%d";
+    private static final String MAJOR_FORMAT = "%d.0.0";
+    private static final String MAJOR_MINOR_FORMAT = "%d.%d.0";
 
     private Modifier() {
     }
@@ -24,23 +27,14 @@ public class Modifier {
             nextMajor = nextMajor + 1;
         }
 
-        return new Semver(createFullVersion(version, format(Locale.ROOT, "%d.0.0", nextMajor), emptyList()));
+        String newVersion = createFullVersion(version, format(Locale.ROOT, MAJOR_FORMAT, nextMajor), emptyList());
+        return new Semver(newVersion);
     }
 
     @NotNull
     public static Semver withIncMajor(@NotNull final Semver version, int number) {
-        return new Semver(
-                createFullVersion(
-                        version,
-                        format(
-                                Locale.ROOT,
-                                "%d.%d.%d",
-                                (version.getMajor() + number),
-                                version.getMinor(),
-                                version.getPatch()
-                        ),
-                        version.getPreRelease())
-        );
+        String newVersion = createFullVersion(version, format(Locale.ROOT, FULL_FORMAT, (version.getMajor() + number), version.getMinor(), version.getPatch()), version.getPreRelease());
+        return new Semver(newVersion);
     }
 
     @NotNull
@@ -52,30 +46,14 @@ public class Modifier {
             nextMinor = nextMinor + 1;
         }
 
-        return new Semver(
-                createFullVersion(
-                        version,
-                        format(Locale.ROOT, "%d.%d.0", version.getMajor(), nextMinor),
-                        emptyList()
-                )
-        );
+        String newVersion = createFullVersion(version, format(Locale.ROOT, MAJOR_MINOR_FORMAT, version.getMajor(), nextMinor), emptyList());
+        return new Semver(newVersion);
     }
 
     @NotNull
     public static Semver withIncMinor(@NotNull final Semver version, int number) {
-        return new Semver(
-                createFullVersion(
-                        version,
-                        format(
-                                Locale.ROOT,
-                                "%d.%d.%d",
-                                version.getMajor(),
-                                (version.getMinor() + number),
-                                version.getPatch()
-                        ),
-                        version.getPreRelease()
-                )
-        );
+        String newVersion = createFullVersion(version, format(Locale.ROOT, FULL_FORMAT, version.getMajor(), (version.getMinor() + number), version.getPatch()), version.getPreRelease());
+        return new Semver(newVersion);
     }
 
     @NotNull
@@ -87,83 +65,48 @@ public class Modifier {
             newPatch = newPatch + 1;
         }
 
-        return new Semver(
-                createFullVersion(
-                        version,
-                        format(Locale.ROOT, "%d.%d.%d", version.getMajor(), version.getMinor(), newPatch),
-                        emptyList()
-                )
-        );
+        String newVersion = createFullVersion(version, format(Locale.ROOT, FULL_FORMAT, version.getMajor(), version.getMinor(), newPatch), emptyList());
+        return new Semver(newVersion);
     }
 
     @NotNull
     public static Semver withIncPatch(@NotNull final Semver version, int number) {
-        return new Semver(
-                createFullVersion(
-                        version,
-                        format(
-                                Locale.ROOT,
-                                "%d.%d.%d",
-                                version.getMajor(),
-                                version.getMinor(),
-                                (version.getPatch() + number)
-                        ),
-                        version.getPreRelease()
-                )
-        );
+        String newVersion = createFullVersion(version, format(Locale.ROOT, FULL_FORMAT, version.getMajor(), version.getMinor(), (version.getPatch() + number)), version.getPreRelease());
+        return new Semver(newVersion);
     }
 
     @NotNull
     public static Semver withPreRelease(@NotNull final Semver version, @NotNull final String preRelease) {
         List<String> newPreRelease = asList(preRelease.split("\\."));
 
-        return new Semver(
-                createFullVersion(
-                        version,
-                        format(Locale.ROOT, "%d.%d.%d", version.getMajor(), version.getMinor(), version.getPatch()),
-                        newPreRelease
-                )
-        );
+        String newVersion = createFullVersion(version, format(Locale.ROOT, FULL_FORMAT, version.getMajor(), version.getMinor(), version.getPatch()), newPreRelease);
+        return new Semver(newVersion);
     }
 
     @NotNull
     public static Semver withBuild(@NotNull final Semver version, @NotNull final String build) {
         List<String> newBuild = asList(build.split("\\."));
 
-        return new Semver(
-                createFullVersion(
-                        format(Locale.ROOT, "%d.%d.%d", version.getMajor(), version.getMinor(), version.getPatch()),
-                        version.getPreRelease(),
-                        newBuild
-                )
-        );
+        String newVersion = createFullVersion(format(Locale.ROOT, FULL_FORMAT, version.getMajor(), version.getMinor(), version.getPatch()), version.getPreRelease(), newBuild);
+        return new Semver(newVersion);
     }
 
     @NotNull
     public static Semver withClearedPreRelease(@NotNull final Semver version) {
-        return new Semver(
-                createFullVersion(
-                        version,
-                        format(Locale.ROOT, "%d.%d.%d", version.getMajor(), version.getMinor(), version.getPatch()),
-                        emptyList()
-                )
-        );
+        String newVersion = createFullVersion(version, format(Locale.ROOT, FULL_FORMAT, version.getMajor(), version.getMinor(), version.getPatch()), emptyList());
+        return new Semver(newVersion);
     }
 
     @NotNull
     public static Semver withClearedBuild(@NotNull final Semver version) {
-        return new Semver(
-                createFullVersion(
-                        format(Locale.ROOT, "%d.%d.%d", version.getMajor(), version.getMinor(), version.getPatch()),
-                        version.getPreRelease(),
-                        emptyList()
-                )
-        );
+        String newVersion = createFullVersion(format(Locale.ROOT, FULL_FORMAT, version.getMajor(), version.getMinor(), version.getPatch()), version.getPreRelease(), emptyList());
+        return new Semver(newVersion);
     }
 
     @NotNull
     public static Semver withClearedPreReleaseAndBuild(@NotNull final Semver version) {
-        return new Semver(format(Locale.ROOT, "%d.%d.%d", version.getMajor(), version.getMinor(), version.getPatch()));
+        String newVersion = format(Locale.ROOT, FULL_FORMAT, version.getMajor(), version.getMinor(), version.getPatch());
+        return new Semver(newVersion);
     }
 
     @NotNull

--- a/src/main/java/org/semver4j/internal/StrictParser.java
+++ b/src/main/java/org/semver4j/internal/StrictParser.java
@@ -24,8 +24,11 @@ public class StrictParser {
     @NotNull
     private static final BigInteger maxInt = BigInteger.valueOf(Integer.MAX_VALUE);
 
+    private StrictParser() {
+    }
+
     @NotNull
-    public Version parse(@NotNull final String version) {
+    public static Version parse(@NotNull final String version) {
         Matcher matcher = pattern.matcher(version);
 
         if (!matcher.matches()) {
@@ -41,7 +44,7 @@ public class StrictParser {
         return new Version(major, minor, patch, preRelease, build);
     }
 
-    private int parseInt(@NotNull final String maybeInt) {
+    private static int parseInt(@NotNull final String maybeInt) {
         BigInteger secureNumber = new BigInteger(maybeInt);
         if (maxInt.compareTo(secureNumber) < 0) {
             throw new SemverException(format(Locale.ROOT, "Value [%s] is too big.", maybeInt));
@@ -56,7 +59,7 @@ public class StrictParser {
     }
 
     @NotNull
-    private List<@NotNull String> convertToList(@Nullable final String toList) {
+    private static List<@NotNull String> convertToList(@Nullable final String toList) {
         return toList == null ? emptyList() : asList(toList.split("\\."));
     }
 

--- a/src/main/java/org/semver4j/internal/Tokenizers.java
+++ b/src/main/java/org/semver4j/internal/Tokenizers.java
@@ -98,7 +98,4 @@ public class Tokenizers {
 
     @NotNull
     public static final String COMPARATOR = format(Locale.ROOT, "^%s\\s*(%s)$|^$", GLTL, STRICT_PLAIN);
-
-    @NotNull
-    public static final String COERCE = "(^|[^\\d])(\\d{1,16})(?:\\.(\\d{1,16}))?(?:\\.(\\d{1,16}))?(?:$|[^\\d])";
 }

--- a/src/test/java/org/semver4j/internal/StrictParserTest.java
+++ b/src/test/java/org/semver4j/internal/StrictParserTest.java
@@ -23,11 +23,8 @@ class StrictParserTest {
     @ParameterizedTest
     @MethodSource("validStrictSemver")
     void shouldParseValidVersions(String version, Version expected) {
-        //given
-        StrictParser strictParser = new StrictParser();
-
         //when
-        Version actual = strictParser.parse(version);
+        Version actual = StrictParser.parse(version);
 
         //then
         assertThat(actual).isEqualTo(expected);
@@ -71,22 +68,16 @@ class StrictParserTest {
     @ParameterizedTest
     @MethodSource("invalidStrictSemver")
     void shouldParseInvalidVersions(String version) {
-        //given
-        StrictParser strictParser = new StrictParser();
-
         //when/then
-        assertThatThrownBy(() -> strictParser.parse(version))
+        assertThatThrownBy(() -> StrictParser.parse(version))
             .isInstanceOf(SemverException.class)
             .hasMessage(format(Locale.ROOT, "Version [%s] is not valid semver.", version));
     }
 
     @Test
     void shouldParseInvalidVersions() {
-        //given
-        StrictParser strictParser = new StrictParser();
-
         //when/then
-        assertThatThrownBy(() -> strictParser.parse("99999999999999999999999.999999999999999999.99999999999999999"))
+        assertThatThrownBy(() -> StrictParser.parse("99999999999999999999999.999999999999999999.99999999999999999"))
             .isInstanceOf(SemverException.class)
             .hasMessage(format(Locale.ROOT, "Value [%s] is too big.", "99999999999999999999999"));
     }
@@ -140,11 +131,8 @@ class StrictParserTest {
     @ParameterizedTest
     @ValueSource(strings = {"1", "99999999999999999999999.999999999999999999.99999999999999999"})
     void shouldThrowSemverExceptionWhichExtendsIllegalArgumentException(String version) {
-        //given
-        StrictParser strictParser = new StrictParser();
-
         //when/then
-        assertThatThrownBy(() -> strictParser.parse(version))
+        assertThatThrownBy(() -> StrictParser.parse(version))
             .isInstanceOf(IllegalArgumentException.class);
     }
 }


### PR DESCRIPTION
Internal package classes are now containers of pure functions; Slight refinements of Coerce to directly use pattern-matching string as well as Optional for parsing nullable values

Fixes #239