### PR TITLE
RangeProcessorPipeline iterative processing

### DIFF
--- a/src/main/java/org/semver4j/internal/range/RangeProcessorPipeline.java
+++ b/src/main/java/org/semver4j/internal/range/RangeProcessorPipeline.java
@@ -3,22 +3,29 @@ package org.semver4j.internal.range;
 import org.jetbrains.annotations.NotNull;
 import org.semver4j.internal.range.processor.Processor;
 
+import java.util.ArrayList;
+
 public class RangeProcessorPipeline {
     @NotNull
-    private final Processor currentProcessor;
+    private final ArrayList<@NotNull Processor> processors = new ArrayList<>();
 
     public RangeProcessorPipeline(@NotNull final Processor currentProcessor) {
-        this.currentProcessor = currentProcessor;
+        this.processors.add(currentProcessor);
     }
 
     @NotNull
     public RangeProcessorPipeline addProcessor(@NotNull final Processor processor) {
-        return new RangeProcessorPipeline(version -> processor.process(currentProcessor.process(version)));
+        processors.add(processor);
+        return this;
     }
 
     @NotNull
     public String process(@NotNull final String range) {
-        return currentProcessor.process(range);
+        String processedRange = range;
+        for (Processor processor : processors) {
+            processedRange = processor.process(processedRange);
+        }
+        return processedRange;
     }
 
     @NotNull

--- a/src/test/java/org/semver4j/internal/range/RangeProcessorPipelineTest.java
+++ b/src/test/java/org/semver4j/internal/range/RangeProcessorPipelineTest.java
@@ -1,0 +1,20 @@
+package org.semver4j.internal.range;
+
+import org.junit.jupiter.api.Test;
+import org.semver4j.internal.range.processor.Processor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RangeProcessorPipelineTest {
+    private final Processor processorA = range -> range + "_A";
+    private final Processor processorB = range -> range + "_B";
+    private final Processor processorC = range -> range + "_C";
+
+    @Test
+    void shouldBeAbleToBuildAPipeline() {
+        RangeProcessorPipeline pipeline = RangeProcessorPipeline.startWith(processorA)
+                .addProcessor(processorB)
+                .addProcessor(processorC);
+        assertThat(pipeline.process("RANGE")).isEqualTo("RANGE_A_B_C");
+    }
+}


### PR DESCRIPTION
Converted `RangeProcessorPipeline` to use iterative processing of range strings instead of recursive processing. This will improve readability during debugging of range pipeline parsing as well as reduce churn by not having to create a new instance of `RangeProcessorPipeline` each time a new `Processor` instance is added.