### PR TITLE
Reworking range processors to short-circuit when a suitable parsed range is found

### DIFF
--- a/src/main/java/org/semver4j/RangesString.java
+++ b/src/main/java/org/semver4j/RangesString.java
@@ -1,8 +1,13 @@
 package org.semver4j;
 
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.semver4j.internal.range.processor.*;
+import org.semver4j.internal.range.RangeProcessorPipeline;
+import org.semver4j.internal.range.processor.AllVersionsProcessor;
+import org.semver4j.internal.range.processor.CaretProcessor;
+import org.semver4j.internal.range.processor.HyphenProcessor;
+import org.semver4j.internal.range.processor.IvyProcessor;
+import org.semver4j.internal.range.processor.TildeProcessor;
+import org.semver4j.internal.range.processor.XRangeProcessor;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,6 +23,13 @@ class RangesString {
     private static final Pattern splitterPattern = compile("(\\s*)([<>]?=?)\\s*");
     @NotNull
     private static final Pattern comparatorPattern = compile(COMPARATOR);
+    @NotNull
+    private static final RangeProcessorPipeline rangeProcessorPipeline = startWith(new AllVersionsProcessor())
+            .addProcessor(new IvyProcessor())
+            .addProcessor(new HyphenProcessor())
+            .addProcessor(new CaretProcessor())
+            .addProcessor(new TildeProcessor())
+            .addProcessor(new XRangeProcessor());
 
     @NotNull
     RangesList get(@NotNull String range) {
@@ -42,15 +54,9 @@ class RangesString {
         return matcher.replaceAll("$1$2").trim();
     }
 
-    @Nullable
-    private static String applyProcessors(@Nullable final String range) {
-        return startWith(new GreaterThanOrEqualZeroProcessor())
-            .addProcessor(new IvyProcessor())
-            .addProcessor(new HyphenProcessor())
-            .addProcessor(new CaretProcessor())
-            .addProcessor(new TildeProcessor())
-            .addProcessor(new XRangeProcessor())
-            .process(range);
+    @NotNull
+    private static String applyProcessors(@NotNull final String range) {
+        return rangeProcessorPipeline.process(range);
     }
 
     @NotNull

--- a/src/main/java/org/semver4j/internal/range/RangeProcessorPipeline.java
+++ b/src/main/java/org/semver4j/internal/range/RangeProcessorPipeline.java
@@ -21,11 +21,13 @@ public class RangeProcessorPipeline {
 
     @NotNull
     public String process(@NotNull final String range) {
-        String processedRange = range;
         for (Processor processor : processors) {
-            processedRange = processor.process(processedRange);
+            String processedRange = processor.tryProcess(range);
+            if (processedRange != null) {
+                return processedRange;
+            }
         }
-        return processedRange;
+        return range;
     }
 
     @NotNull

--- a/src/main/java/org/semver4j/internal/range/processor/AllVersionsProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/AllVersionsProcessor.java
@@ -10,20 +10,18 @@ import static java.lang.String.format;
 import static org.semver4j.Range.RangeOperator.GTE;
 
 /**
- * <p>Processor for translate {@code latest}, {@code latest.integration} and {@code *} strings into classic range.</p>
+ * <p>Processor for translating {@code *} and empty strings into a classic range.</p>
  * <br>
  * Translates:
  * <ul>
- *     <li>all ranges to {@code ≥0.0.0}</li>
+ *     <li>{@code *} to {@code ≥0.0.0}</li>
+ *     <li>an empty string to {@code ≥0.0.0}</li>
  * </ul>
- *
- * @deprecated behavior has been split off into {@link AllVersionsProcessor} and {@link IvyProcessor}
  */
-@Deprecated
-public class GreaterThanOrEqualZeroProcessor implements Processor {
+public class AllVersionsProcessor implements Processor {
     @Override
     public @Nullable String tryProcess(@NotNull String range) {
-        if (range.equals("latest") || range.equals("latest.integration") || range.equals("*") || range.isEmpty()) {
+        if (range.equals("*") || range.isEmpty()) {
             return format(Locale.ROOT, "%s%s", GTE.asString(), Semver.ZERO);
         }
         return null;

--- a/src/main/java/org/semver4j/internal/range/processor/AllVersionsProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/AllVersionsProcessor.java
@@ -15,7 +15,7 @@ import static org.semver4j.Range.RangeOperator.GTE;
  * Translates:
  * <ul>
  *     <li>{@code *} to {@code ≥0.0.0}</li>
- *     <li>an empty string to {@code ≥0.0.0}</li>
+ *     <li>An empty string to {@code ≥0.0.0}</li>
  * </ul>
  */
 public class AllVersionsProcessor implements Processor {

--- a/src/main/java/org/semver4j/internal/range/processor/CaretProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/CaretProcessor.java
@@ -12,8 +12,6 @@ import static java.util.regex.Pattern.compile;
 import static org.semver4j.Range.RangeOperator.GTE;
 import static org.semver4j.Range.RangeOperator.LT;
 import static org.semver4j.internal.Tokenizers.CARET;
-import static org.semver4j.internal.range.processor.RangesUtils.ALL_RANGE;
-import static org.semver4j.internal.range.processor.RangesUtils.ASTERISK;
 import static org.semver4j.internal.range.processor.RangesUtils.isNotBlank;
 import static org.semver4j.internal.range.processor.RangesUtils.isX;
 import static org.semver4j.internal.range.processor.RangesUtils.parseIntWithXSupport;
@@ -34,10 +32,6 @@ public class CaretProcessor implements Processor {
 
     @Override
     public @Nullable String tryProcess(@NotNull String range) {
-        if (range.equals(ASTERISK)) {
-            return ALL_RANGE;
-        }
-
         Matcher matcher = pattern.matcher(range);
 
         if (!matcher.matches()) {

--- a/src/main/java/org/semver4j/internal/range/processor/CaretProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/CaretProcessor.java
@@ -1,6 +1,7 @@
 package org.semver4j.internal.range.processor;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Locale;
 import java.util.regex.Matcher;
@@ -11,7 +12,9 @@ import static java.util.regex.Pattern.compile;
 import static org.semver4j.Range.RangeOperator.GTE;
 import static org.semver4j.Range.RangeOperator.LT;
 import static org.semver4j.internal.Tokenizers.CARET;
-import static org.semver4j.internal.range.processor.RangesUtils.*;
+import static org.semver4j.internal.range.processor.RangesUtils.isNotBlank;
+import static org.semver4j.internal.range.processor.RangesUtils.isX;
+import static org.semver4j.internal.range.processor.RangesUtils.parseIntWithXSupport;
 
 /**
  * <p>Processor for translate <a href="https://github.com/npm/node-semver#caret-ranges-123-025-004">caret ranges</a>
@@ -28,8 +31,7 @@ public class CaretProcessor implements Processor {
     private static final Pattern pattern = compile(CARET);
 
     @Override
-    @NotNull
-    public String process(@NotNull final String range) {
+    public @Nullable String tryProcess(@NotNull String range) {
         Matcher matcher = pattern.matcher(range);
 
         if (!matcher.matches()) {

--- a/src/main/java/org/semver4j/internal/range/processor/CaretProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/CaretProcessor.java
@@ -12,6 +12,8 @@ import static java.util.regex.Pattern.compile;
 import static org.semver4j.Range.RangeOperator.GTE;
 import static org.semver4j.Range.RangeOperator.LT;
 import static org.semver4j.internal.Tokenizers.CARET;
+import static org.semver4j.internal.range.processor.RangesUtils.ALL_RANGE;
+import static org.semver4j.internal.range.processor.RangesUtils.ASTERISK;
 import static org.semver4j.internal.range.processor.RangesUtils.isNotBlank;
 import static org.semver4j.internal.range.processor.RangesUtils.isX;
 import static org.semver4j.internal.range.processor.RangesUtils.parseIntWithXSupport;
@@ -32,21 +34,20 @@ public class CaretProcessor implements Processor {
 
     @Override
     public @Nullable String tryProcess(@NotNull String range) {
+        if (range.equals(ASTERISK)) {
+            return ALL_RANGE;
+        }
+
         Matcher matcher = pattern.matcher(range);
 
         if (!matcher.matches()) {
-            return range;
+            return null;
         }
-
-        // Left unused variables for brevity.
-
-        String fullRange = matcher.group(0);
 
         int major = parseIntWithXSupport(matcher.group(1));
         int minor = parseIntWithXSupport(matcher.group(2));
         int path = parseIntWithXSupport(matcher.group(3));
         String preRelease = matcher.group(4);
-        String build = matcher.group(5);
 
         boolean minorIsX = isX(minor);
         boolean patchIsX = isX(path);

--- a/src/main/java/org/semver4j/internal/range/processor/GreaterThanOrEqualZeroProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/GreaterThanOrEqualZeroProcessor.java
@@ -1,12 +1,13 @@
 package org.semver4j.internal.range.processor;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.semver4j.Semver;
+
+import java.util.Locale;
 
 import static java.lang.String.format;
 import static org.semver4j.Range.RangeOperator.GTE;
-
-import java.util.Locale;
 
 /**
  * <p>Processor for translate {@code latest}, {@code latest.internal} and {@code *} strings into classic range.</p>
@@ -18,8 +19,7 @@ import java.util.Locale;
  */
 public class GreaterThanOrEqualZeroProcessor implements Processor {
     @Override
-    @NotNull
-    public String process(@NotNull final String range) {
+    public @Nullable String tryProcess(@NotNull String range) {
         if (range.equals("latest") || range.equals("latest.integration") || range.equals("*") || range.isEmpty()) {
             return format(Locale.ROOT, "%s%s", GTE.asString(), Semver.ZERO);
         }

--- a/src/main/java/org/semver4j/internal/range/processor/GreaterThanOrEqualZeroProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/GreaterThanOrEqualZeroProcessor.java
@@ -10,7 +10,7 @@ import static java.lang.String.format;
 import static org.semver4j.Range.RangeOperator.GTE;
 
 /**
- * <p>Processor for translate {@code latest}, {@code latest.internal} and {@code *} strings into classic range.</p>
+ * <p>Processor for translate {@code *} strings and empty strings into classic range.</p>
  * <br>
  * Translates:
  * <ul>
@@ -20,9 +20,9 @@ import static org.semver4j.Range.RangeOperator.GTE;
 public class GreaterThanOrEqualZeroProcessor implements Processor {
     @Override
     public @Nullable String tryProcess(@NotNull String range) {
-        if (range.equals("latest") || range.equals("latest.integration") || range.equals("*") || range.isEmpty()) {
+        if (range.equals("*") || range.isEmpty()) {
             return format(Locale.ROOT, "%s%s", GTE.asString(), Semver.ZERO);
         }
-        return range;
+        return null;
     }
 }

--- a/src/main/java/org/semver4j/internal/range/processor/HyphenProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/HyphenProcessor.java
@@ -37,7 +37,7 @@ public class HyphenProcessor implements Processor {
         Matcher matcher = pattern.matcher(range);
 
         if (!matcher.matches()) {
-            return range;
+            return null;
         }
 
         String rangeFrom = getRangeFrom(matcher);
@@ -48,15 +48,11 @@ public class HyphenProcessor implements Processor {
 
     @NotNull
     private String getRangeFrom(@NotNull final Matcher matcher) {
-        // Left unused variables for brevity.
-
         String from = matcher.group(1);
 
         int fromMajor = parseIntWithXSupport(matcher.group(2));
         int fromMinor = parseIntWithXSupport(matcher.group(3));
         int fromPatch = parseIntWithXSupport(matcher.group(4));
-        String fromPreRelease = matcher.group(5);
-        String fromBuild = matcher.group(6);
 
         boolean minorIsX = isX(fromMinor);
         boolean patchIsX = isX(fromPatch);
@@ -74,15 +70,11 @@ public class HyphenProcessor implements Processor {
 
     @NotNull
     private String getRangeTo(@NotNull final Matcher matcher) {
-        // Left unused variables for brevity.
-
         String to = matcher.group(7);
 
         int toMajor = parseIntWithXSupport(matcher.group(8));
         int toMinor = parseIntWithXSupport(matcher.group(9));
         int toPatch = parseIntWithXSupport(matcher.group(10));
-        String toPreRelease = matcher.group(11);
-        String toBuild = matcher.group(12);
 
         boolean minorIsX = isX(toMinor);
         boolean patchIsX = isX(toPatch);

--- a/src/main/java/org/semver4j/internal/range/processor/HyphenProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/HyphenProcessor.java
@@ -1,6 +1,7 @@
 package org.semver4j.internal.range.processor;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Locale;
 import java.util.regex.Matcher;
@@ -8,7 +9,9 @@ import java.util.regex.Pattern;
 
 import static java.lang.String.format;
 import static java.util.regex.Pattern.compile;
-import static org.semver4j.Range.RangeOperator.*;
+import static org.semver4j.Range.RangeOperator.GTE;
+import static org.semver4j.Range.RangeOperator.LT;
+import static org.semver4j.Range.RangeOperator.LTE;
 import static org.semver4j.internal.Tokenizers.HYPHEN;
 import static org.semver4j.internal.range.processor.RangesUtils.isX;
 import static org.semver4j.internal.range.processor.RangesUtils.parseIntWithXSupport;
@@ -30,8 +33,7 @@ public class HyphenProcessor implements Processor {
     private static final Pattern pattern = compile(HYPHEN);
 
     @Override
-    @NotNull
-    public String process(@NotNull final String range) {
+    public @Nullable String tryProcess(@NotNull String range) {
         Matcher matcher = pattern.matcher(range);
 
         if (!matcher.matches()) {

--- a/src/main/java/org/semver4j/internal/range/processor/IvyProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/IvyProcessor.java
@@ -2,6 +2,7 @@ package org.semver4j.internal.range.processor;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.semver4j.Semver;
 
 import java.util.Locale;
 import java.util.regex.Matcher;
@@ -35,20 +36,23 @@ import static org.semver4j.internal.range.processor.RangesUtils.parseIntWithXSup
  * </ul>
  */
 public class IvyProcessor implements Processor {
+    private static final String LATEST = "latest";
+    private static final String LATEST_INTEGRATION = LATEST + ".integration";
+
     @NotNull
     private static final Pattern PATTERN = compile(IVY);
 
     @Override
     public @Nullable String tryProcess(@NotNull String range) {
+        if (range.equals(LATEST) || range.equals(LATEST_INTEGRATION)) {
+            return format(Locale.ROOT, "%s%s", GTE.asString(), Semver.ZERO);
+        }
+
         Matcher matcher = PATTERN.matcher(range);
 
         if (!matcher.matches()) {
-            return range;
+            return null;
         }
-
-        // Left unused variables for brevity.
-
-        String fullRange = matcher.group(0);
 
         String openSign = matcher.group(1);
 

--- a/src/main/java/org/semver4j/internal/range/processor/IvyProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/IvyProcessor.java
@@ -2,7 +2,6 @@ package org.semver4j.internal.range.processor;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.semver4j.Semver;
 
 import java.util.Locale;
 import java.util.regex.Matcher;
@@ -15,6 +14,7 @@ import static org.semver4j.Range.RangeOperator.GTE;
 import static org.semver4j.Range.RangeOperator.LT;
 import static org.semver4j.Range.RangeOperator.LTE;
 import static org.semver4j.internal.Tokenizers.IVY;
+import static org.semver4j.internal.range.processor.RangesUtils.ALL_RANGE;
 import static org.semver4j.internal.range.processor.RangesUtils.isX;
 import static org.semver4j.internal.range.processor.RangesUtils.parseIntWithXSupport;
 
@@ -45,7 +45,7 @@ public class IvyProcessor implements Processor {
     @Override
     public @Nullable String tryProcess(@NotNull String range) {
         if (range.equals(LATEST) || range.equals(LATEST_INTEGRATION)) {
-            return format(Locale.ROOT, "%s%s", GTE.asString(), Semver.ZERO);
+            return ALL_RANGE;
         }
 
         Matcher matcher = PATTERN.matcher(range);

--- a/src/main/java/org/semver4j/internal/range/processor/IvyProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/IvyProcessor.java
@@ -1,6 +1,7 @@
 package org.semver4j.internal.range.processor;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Locale;
 import java.util.regex.Matcher;
@@ -8,7 +9,10 @@ import java.util.regex.Pattern;
 
 import static java.lang.String.format;
 import static java.util.regex.Pattern.compile;
-import static org.semver4j.Range.RangeOperator.*;
+import static org.semver4j.Range.RangeOperator.GT;
+import static org.semver4j.Range.RangeOperator.GTE;
+import static org.semver4j.Range.RangeOperator.LT;
+import static org.semver4j.Range.RangeOperator.LTE;
 import static org.semver4j.internal.Tokenizers.IVY;
 import static org.semver4j.internal.range.processor.RangesUtils.isX;
 import static org.semver4j.internal.range.processor.RangesUtils.parseIntWithXSupport;
@@ -35,8 +39,7 @@ public class IvyProcessor implements Processor {
     private static final Pattern PATTERN = compile(IVY);
 
     @Override
-    @NotNull
-    public String process(@NotNull final String range) {
+    public @Nullable String tryProcess(@NotNull String range) {
         Matcher matcher = PATTERN.matcher(range);
 
         if (!matcher.matches()) {

--- a/src/main/java/org/semver4j/internal/range/processor/IvyProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/IvyProcessor.java
@@ -33,6 +33,8 @@ import static org.semver4j.internal.range.processor.RangesUtils.parseIntWithXSup
  *     <li>{@code ]1.0,)} to {@code >1.0.0}</li>
  *     <li>{@code (,2.0]} to {@code ≤2.0.0}</li>
  *     <li>{@code (,2.0[} to {@code <2.0.0}</li>
+ *     <li>{@code latest} to {@code ≥0.0.0}</li>
+ *     <li>{@code latest.integration} to {@code ≥0.0.0}</li>
  * </ul>
  */
 public class IvyProcessor implements Processor {

--- a/src/main/java/org/semver4j/internal/range/processor/Processor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/Processor.java
@@ -1,11 +1,20 @@
 package org.semver4j.internal.range.processor;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
 
 /**
  * Processor for pipeline range translations.
  */
 public interface Processor {
+    @Deprecated
     @NotNull
-    String process(@NotNull String range);
+    default String process(@NotNull String range) {
+        return Optional.ofNullable(tryProcess(range)).orElse(range);
+    };
+
+    @Nullable
+    String tryProcess(@NotNull String range);
 }

--- a/src/main/java/org/semver4j/internal/range/processor/RangesUtils.java
+++ b/src/main/java/org/semver4j/internal/range/processor/RangesUtils.java
@@ -2,8 +2,13 @@ package org.semver4j.internal.range.processor;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.semver4j.Semver;
+
+import java.util.Locale;
 
 import static java.lang.Integer.parseInt;
+import static java.lang.String.format;
+import static org.semver4j.Range.RangeOperator.GTE;
 
 /**
  * Set of methods which helps ranges handling.
@@ -13,6 +18,10 @@ final class RangesUtils {
     static final String EMPTY = "";
     @NotNull
     static final String SPACE = " ";
+    @NotNull
+    static final String ASTERISK = "*";
+    @NotNull
+    static final String ALL_RANGE = format(Locale.ROOT, "%s%s", GTE.asString(), Semver.ZERO);
 
     private static final int X_RANGE_MARKER = -1;
 

--- a/src/main/java/org/semver4j/internal/range/processor/RangesUtils.java
+++ b/src/main/java/org/semver4j/internal/range/processor/RangesUtils.java
@@ -19,8 +19,6 @@ final class RangesUtils {
     @NotNull
     static final String SPACE = " ";
     @NotNull
-    static final String ASTERISK = "*";
-    @NotNull
     static final String ALL_RANGE = format(Locale.ROOT, "%s%s", GTE.asString(), Semver.ZERO);
 
     private static final int X_RANGE_MARKER = -1;

--- a/src/main/java/org/semver4j/internal/range/processor/TildeProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/TildeProcessor.java
@@ -39,18 +39,13 @@ public class TildeProcessor implements Processor {
         Matcher matcher = pattern.matcher(range);
 
         if (!matcher.matches()) {
-            return range;
+            return null;
         }
-
-        // Left unused variables for brevity.
-
-        String fullRange = matcher.group(0);
 
         int major = parseIntWithXSupport(matcher.group(1));
         int minor = parseIntWithXSupport(matcher.group(2));
         int path = parseIntWithXSupport(matcher.group(3));
         String preRelease = matcher.group(4);
-        String build = matcher.group(5);
 
         String from;
         String to;

--- a/src/main/java/org/semver4j/internal/range/processor/TildeProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/TildeProcessor.java
@@ -1,6 +1,7 @@
 package org.semver4j.internal.range.processor;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Locale;
 import java.util.regex.Matcher;
@@ -11,7 +12,9 @@ import static java.util.regex.Pattern.compile;
 import static org.semver4j.Range.RangeOperator.GTE;
 import static org.semver4j.Range.RangeOperator.LT;
 import static org.semver4j.internal.Tokenizers.TILDE;
-import static org.semver4j.internal.range.processor.RangesUtils.*;
+import static org.semver4j.internal.range.processor.RangesUtils.isNotBlank;
+import static org.semver4j.internal.range.processor.RangesUtils.isX;
+import static org.semver4j.internal.range.processor.RangesUtils.parseIntWithXSupport;
 
 /**
  * <p>Processor for translate <a href="https://github.com/npm/node-semver#tilde-ranges-123-12-1">tilde ranges</a>
@@ -32,8 +35,7 @@ public class TildeProcessor implements Processor {
     private static final Pattern pattern = compile(TILDE);
 
     @Override
-    @NotNull
-    public String process(@NotNull final String range) {
+    public @Nullable String tryProcess(@NotNull String range) {
         Matcher matcher = pattern.matcher(range);
 
         if (!matcher.matches()) {

--- a/src/main/java/org/semver4j/internal/range/processor/XRangeProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/XRangeProcessor.java
@@ -1,6 +1,7 @@
 package org.semver4j.internal.range.processor;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -11,9 +12,16 @@ import java.util.regex.Pattern;
 import static java.lang.String.format;
 import static java.lang.String.join;
 import static java.util.regex.Pattern.compile;
-import static org.semver4j.Range.RangeOperator.*;
+import static org.semver4j.Range.RangeOperator.EQ;
+import static org.semver4j.Range.RangeOperator.GT;
+import static org.semver4j.Range.RangeOperator.GTE;
+import static org.semver4j.Range.RangeOperator.LT;
+import static org.semver4j.Range.RangeOperator.LTE;
 import static org.semver4j.internal.Tokenizers.XRANGE;
-import static org.semver4j.internal.range.processor.RangesUtils.*;
+import static org.semver4j.internal.range.processor.RangesUtils.EMPTY;
+import static org.semver4j.internal.range.processor.RangesUtils.SPACE;
+import static org.semver4j.internal.range.processor.RangesUtils.isX;
+import static org.semver4j.internal.range.processor.RangesUtils.parseIntWithXSupport;
 
 /**
  * <p>Processor for translate <a href="https://github.com/npm/node-semver#x-ranges-12x-1x-12-">X-Ranges</a> into classic
@@ -25,8 +33,7 @@ public class XRangeProcessor implements Processor {
     private static final Pattern pattern = compile(XRANGE);
 
     @Override
-    @NotNull
-    public String process(@NotNull final String range) {
+    public @Nullable String tryProcess(@NotNull String range) {
         String[] rangeVersions = range.split("\\s+");
 
         List<String> objects = new ArrayList<>();

--- a/src/main/java/org/semver4j/internal/range/processor/XRangeProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/XRangeProcessor.java
@@ -41,8 +41,6 @@ public class XRangeProcessor implements Processor {
             Matcher matcher = pattern.matcher(rangeVersion);
 
             if (matcher.matches()) {
-                // Left unused variables for brevity.
-
                 String fullRange = matcher.group(0);
 
                 String compareSign = matcher.group(1);
@@ -50,8 +48,6 @@ public class XRangeProcessor implements Processor {
                 int major = parseIntWithXSupport(matcher.group(2));
                 int minor = parseIntWithXSupport(matcher.group(3));
                 int patch = parseIntWithXSupport(matcher.group(4));
-                String preRelease = matcher.group(5);
-                String build = matcher.group(6);
 
                 if (compareSign.equals(EQ.asString()) && isX(patch)) {
                     compareSign = EMPTY;
@@ -99,7 +95,7 @@ public class XRangeProcessor implements Processor {
         }
 
         if (objects.isEmpty()) {
-            return range;
+            return null;
         }
 
         return join(SPACE, objects);

--- a/src/test/java/org/semver4j/internal/range/RangeProcessorPipelineTest.java
+++ b/src/test/java/org/semver4j/internal/range/RangeProcessorPipelineTest.java
@@ -1,20 +1,23 @@
 package org.semver4j.internal.range;
 
 import org.junit.jupiter.api.Test;
-import org.semver4j.internal.range.processor.Processor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class RangeProcessorPipelineTest {
-    private final Processor processorA = range -> range + "_A";
-    private final Processor processorB = range -> range + "_B";
-    private final Processor processorC = range -> range + "_C";
-
     @Test
     void shouldBeAbleToBuildAPipeline() {
-        RangeProcessorPipeline pipeline = RangeProcessorPipeline.startWith(processorA)
-                .addProcessor(processorB)
-                .addProcessor(processorC);
-        assertThat(pipeline.process("RANGE")).isEqualTo("RANGE_A_B_C");
+        RangeProcessorPipeline pipeline = RangeProcessorPipeline.startWith(range -> range + "_A")
+                .addProcessor(range -> range + "_B")
+                .addProcessor(range -> range + "_C");
+        assertThat(pipeline.process("RANGE")).isEqualTo("RANGE_A");
+    }
+
+    @Test
+    void shouldReturnPassedInStringIfNoProcessorIsSuccessful() {
+        RangeProcessorPipeline pipeline = RangeProcessorPipeline.startWith(range -> null)
+                .addProcessor(range -> null)
+                .addProcessor(range -> null);
+        assertThat(pipeline.process("RANGE")).isEqualTo("RANGE");
     }
 }

--- a/src/test/java/org/semver4j/internal/range/processor/AllVersionsProcessorTest.java
+++ b/src/test/java/org/semver4j/internal/range/processor/AllVersionsProcessorTest.java
@@ -9,20 +9,17 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-@SuppressWarnings("deprecation")
-class GreaterThanOrEqualZeroProcessorTest {
-    private final GreaterThanOrEqualZeroProcessor processor = new GreaterThanOrEqualZeroProcessor();
+class AllVersionsProcessorTest {
+    private final AllVersionsProcessor allVersionsProcessor = new AllVersionsProcessor();
 
     @ParameterizedTest
     @MethodSource
-    void shouldParseRanges(String range, String expectedString) {
-        assertThat(processor.tryProcess(range)).isEqualTo(expectedString);
+    void shouldParseAllVersions(String range, String expectedString) {
+        assertThat(allVersionsProcessor.tryProcess(range)).isEqualTo(expectedString);
     }
 
-    static Stream<Arguments> shouldParseRanges() {
+    static Stream<Arguments> shouldParseAllVersions() {
         return Stream.of(
-                arguments("latest", ">=0.0.0"),
-                arguments("latest.integration", ">=0.0.0"),
                 arguments("*", ">=0.0.0"),
                 arguments("", ">=0.0.0"),
                 arguments("INVALID", null)

--- a/src/test/java/org/semver4j/internal/range/processor/CaretProcessorTest.java
+++ b/src/test/java/org/semver4j/internal/range/processor/CaretProcessorTest.java
@@ -26,7 +26,6 @@ class CaretProcessorTest {
                 arguments("^0.1", ">=0.1.0 <0.2.0"),
                 arguments("^0.0.1", ">=0.0.1 <0.0.2"),
                 arguments("^1.0.0-alpha.1", ">=1.0.0-alpha.1 <2.0.0"),
-                arguments("*", ">=0.0.0"),
                 arguments("INVALID", null)
         );
     }

--- a/src/test/java/org/semver4j/internal/range/processor/CaretProcessorTest.java
+++ b/src/test/java/org/semver4j/internal/range/processor/CaretProcessorTest.java
@@ -26,7 +26,8 @@ class CaretProcessorTest {
                 arguments("^0.1", ">=0.1.0 <0.2.0"),
                 arguments("^0.0.1", ">=0.0.1 <0.0.2"),
                 arguments("^1.0.0-alpha.1", ">=1.0.0-alpha.1 <2.0.0"),
-                arguments("INVALID", "INVALID")
+                arguments("*", ">=0.0.0"),
+                arguments("INVALID", null)
         );
     }
 }

--- a/src/test/java/org/semver4j/internal/range/processor/CaretProcessorTest.java
+++ b/src/test/java/org/semver4j/internal/range/processor/CaretProcessorTest.java
@@ -1,54 +1,32 @@
 package org.semver4j.internal.range.processor;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 class CaretProcessorTest {
     private final CaretProcessor processor = new CaretProcessor();
 
-    @Test
-    void shouldParseRangeWhenMinorIsX() {
-        //when
-        String range = processor.process("^1");
-
-        //then
-        assertThat(range).isEqualTo(">=1.0.0 <2.0.0");
+    @ParameterizedTest
+    @MethodSource
+    void shouldParseCaretRange(String range, String expectedString) {
+        assertThat(processor.tryProcess(range)).isEqualTo(expectedString);
     }
 
-    @Test
-    void shouldParseRangeWhenPatchIsX() {
-        //when
-        String range = processor.process("^1.1");
-
-        //then
-        assertThat(range).isEqualTo(">=1.1.0 <2.0.0");
-    }
-
-    @Test
-    void shouldParseRangeWhenPatchIsXAndMajorIsZero() {
-        //when
-        String range = processor.process("^0.1");
-
-        //then
-        assertThat(range).isEqualTo(">=0.1.0 <0.2.0");
-    }
-
-    @Test
-    void shouldParseRangeWhenHasAllVersionNumbers() {
-        //when
-        String range = processor.process("^14.14.20");
-
-        //then
-        assertThat(range).isEqualTo(">=14.14.20 <15.0.0");
-    }
-
-    @Test
-    void shouldParseRangeWhenPreReleaseIsSetMajorIsZero() {
-        //when
-        String range = processor.process("^0.1.0-alpha.1");
-
-        //then
-        assertThat(range).isEqualTo(">=0.1.0-alpha.1 <0.2.0");
+    static Stream<Arguments> shouldParseCaretRange() {
+        return Stream.of(
+                arguments("^1", ">=1.0.0 <2.0.0"),
+                arguments("^1.1", ">=1.1.0 <2.0.0"),
+                arguments("^1.1.1", ">=1.1.1 <2.0.0"),
+                arguments("^0.1", ">=0.1.0 <0.2.0"),
+                arguments("^0.0.1", ">=0.0.1 <0.0.2"),
+                arguments("^1.0.0-alpha.1", ">=1.0.0-alpha.1 <2.0.0"),
+                arguments("INVALID", "INVALID")
+        );
     }
 }

--- a/src/test/java/org/semver4j/internal/range/processor/CaretProcessorTest.java
+++ b/src/test/java/org/semver4j/internal/range/processor/CaretProcessorTest.java
@@ -26,6 +26,7 @@ class CaretProcessorTest {
                 arguments("^0.1", ">=0.1.0 <0.2.0"),
                 arguments("^0.0.1", ">=0.0.1 <0.0.2"),
                 arguments("^1.0.0-alpha.1", ">=1.0.0-alpha.1 <2.0.0"),
+                arguments("^0.1.1-alpha.1", ">=0.1.1-alpha.1 <0.2.0"),
                 arguments("INVALID", null)
         );
     }

--- a/src/test/java/org/semver4j/internal/range/processor/GreaterThanOrEqualZeroProcessorTest.java
+++ b/src/test/java/org/semver4j/internal/range/processor/GreaterThanOrEqualZeroProcessorTest.java
@@ -1,20 +1,28 @@
 package org.semver4j.internal.range.processor;
 
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 class GreaterThanOrEqualZeroProcessorTest {
     private final GreaterThanOrEqualZeroProcessor processor = new GreaterThanOrEqualZeroProcessor();
 
     @ParameterizedTest
-    @ValueSource(strings = {"latest", "latest.integration", "*", ""})
-    void shouldParseRanges(String range) {
-        //when
-        String actualRange = processor.process(range);
+    @MethodSource
+    void shouldParseRanges(String range, String expectedString) {
+        assertThat(processor.tryProcess(range)).isEqualTo(expectedString);
+    }
 
-        //then
-        assertThat(actualRange).isEqualTo(">=0.0.0");
+    static Stream<Arguments> shouldParseRanges() {
+        return Stream.of(
+                arguments("*", ">=0.0.0"),
+                arguments("", ">=0.0.0"),
+                arguments("INVALID", null)
+        );
     }
 }

--- a/src/test/java/org/semver4j/internal/range/processor/HyphenProcessorTest.java
+++ b/src/test/java/org/semver4j/internal/range/processor/HyphenProcessorTest.java
@@ -1,0 +1,31 @@
+package org.semver4j.internal.range.processor;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class HyphenProcessorTest {
+    private final HyphenProcessor hyphenProcessor = new HyphenProcessor();
+
+    @ParameterizedTest
+    @MethodSource
+    void shouldParseHyphenRange(String range, String expectedString) {
+        assertThat(hyphenProcessor.tryProcess(range)).isEqualTo(expectedString);
+    }
+
+    static Stream<Arguments> shouldParseHyphenRange() {
+        return Stream.of(
+                arguments("1.2.3 - 2.3.4", ">=1.2.3 <=2.3.4"),
+                arguments("1.2 - 2.3.4", ">=1.2.0 <=2.3.4"),
+                arguments("1 - 2.3.4", ">=1.0.0 <=2.3.4"),
+                arguments("1.2.3 - 2.3", ">=1.2.3 <2.4.0"),
+                arguments("1.2.3 - 2", ">=1.2.3 <3.0.0"),
+                arguments("INVALID", "INVALID")
+        );
+    }
+}

--- a/src/test/java/org/semver4j/internal/range/processor/HyphenProcessorTest.java
+++ b/src/test/java/org/semver4j/internal/range/processor/HyphenProcessorTest.java
@@ -25,7 +25,7 @@ class HyphenProcessorTest {
                 arguments("1 - 2.3.4", ">=1.0.0 <=2.3.4"),
                 arguments("1.2.3 - 2.3", ">=1.2.3 <2.4.0"),
                 arguments("1.2.3 - 2", ">=1.2.3 <3.0.0"),
-                arguments("INVALID", "INVALID")
+                arguments("INVALID", null)
         );
     }
 }

--- a/src/test/java/org/semver4j/internal/range/processor/IvyProcessorTest.java
+++ b/src/test/java/org/semver4j/internal/range/processor/IvyProcessorTest.java
@@ -34,7 +34,9 @@ class IvyProcessorTest {
                 arguments("]1.0.1,2.0.1[", ">1.0.1 <2.0.1"),
                 arguments("[1.0,2.0.1]", ">=1.0.0 <=2.0.1"),
                 arguments("[1.0.1,2.0]", ">=1.0.1 <=2.0.0"),
-                arguments("INVALID", "INVALID")
+                arguments("latest", ">=0.0.0"),
+                arguments("latest.integration", ">=0.0.0"),
+                arguments("INVALID", null)
         );
     }
 }

--- a/src/test/java/org/semver4j/internal/range/processor/IvyProcessorTest.java
+++ b/src/test/java/org/semver4j/internal/range/processor/IvyProcessorTest.java
@@ -10,35 +10,31 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 class IvyProcessorTest {
+    private final IvyProcessor ivyProcessor = new IvyProcessor();
+
     @ParameterizedTest
-    @MethodSource("ivy")
+    @MethodSource
     void shouldProcessIvyRanges(String range, String expected) {
-        //given
-        IvyProcessor ivyProcessor = new IvyProcessor();
-
-        //when
-        String actual = ivyProcessor.process(range);
-
-        //then
-        assertThat(actual).isEqualTo(expected);
+        assertThat(ivyProcessor.tryProcess(range)).isEqualTo(expected);
     }
 
-    static Stream<Arguments> ivy() {
+    static Stream<Arguments> shouldProcessIvyRanges() {
         return Stream.of(
-            arguments("[1.0,2.0]", ">=1.0.0 <=2.0.0"),
-            arguments("[1.0,2.0[", ">=1.0.0 <2.0.0"),
-            arguments("]1.0,2.0]", ">1.0.0 <=2.0.0"),
-            arguments("]1.0,2.0[", ">1.0.0 <2.0.0"),
-            arguments("[1.0,)", ">=1.0.0"),
-            arguments("]1.0,)", ">1.0.0"),
-            arguments("(,2.0]", "<=2.0.0"),
-            arguments("(,2.0[", "<2.0.0"),
-            arguments("[1.0.1,2.0.1]", ">=1.0.1 <=2.0.1"),
-            arguments("]1.0.1,2.0.1]", ">1.0.1 <=2.0.1"),
-            arguments("[1.0.1,2.0.1[", ">=1.0.1 <2.0.1"),
-            arguments("]1.0.1,2.0.1[", ">1.0.1 <2.0.1"),
-            arguments("[1.0,2.0.1]", ">=1.0.0 <=2.0.1"),
-            arguments("[1.0.1,2.0]", ">=1.0.1 <=2.0.0")
+                arguments("[1.0,2.0]", ">=1.0.0 <=2.0.0"),
+                arguments("[1.0,2.0[", ">=1.0.0 <2.0.0"),
+                arguments("]1.0,2.0]", ">1.0.0 <=2.0.0"),
+                arguments("]1.0,2.0[", ">1.0.0 <2.0.0"),
+                arguments("[1.0,)", ">=1.0.0"),
+                arguments("]1.0,)", ">1.0.0"),
+                arguments("(,2.0]", "<=2.0.0"),
+                arguments("(,2.0[", "<2.0.0"),
+                arguments("[1.0.1,2.0.1]", ">=1.0.1 <=2.0.1"),
+                arguments("]1.0.1,2.0.1]", ">1.0.1 <=2.0.1"),
+                arguments("[1.0.1,2.0.1[", ">=1.0.1 <2.0.1"),
+                arguments("]1.0.1,2.0.1[", ">1.0.1 <2.0.1"),
+                arguments("[1.0,2.0.1]", ">=1.0.0 <=2.0.1"),
+                arguments("[1.0.1,2.0]", ">=1.0.1 <=2.0.0"),
+                arguments("INVALID", "INVALID")
         );
     }
 }

--- a/src/test/java/org/semver4j/internal/range/processor/ProcessorTest.java
+++ b/src/test/java/org/semver4j/internal/range/processor/ProcessorTest.java
@@ -1,0 +1,34 @@
+package org.semver4j.internal.range.processor;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("deprecation")
+class ProcessorTest {
+    @Test
+    void nonNullProcessGetsReturned() {
+        Processor nonNullResultProcessor = new Processor() {
+            @Override
+            public @NotNull String tryProcess(@NotNull String range) {
+                return "RESULT";
+            }
+        };
+
+        assertThat(nonNullResultProcessor.process("RANGE")).isEqualTo("RESULT");
+    }
+
+    @Test
+    void nullProcessDoesNotGetReturned() {
+        Processor nullResultProcessor = new Processor() {
+            @Override
+            public @Nullable String tryProcess(@NotNull String range) {
+                return null;
+            }
+        };
+
+        assertThat(nullResultProcessor.process("RANGE")).isEqualTo("RANGE");
+    }
+}

--- a/src/test/java/org/semver4j/internal/range/processor/TildeProcessorTest.java
+++ b/src/test/java/org/semver4j/internal/range/processor/TildeProcessorTest.java
@@ -1,0 +1,30 @@
+package org.semver4j.internal.range.processor;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class TildeProcessorTest {
+    private final TildeProcessor tildeProcessor = new TildeProcessor();
+
+    @ParameterizedTest
+    @MethodSource
+    void shouldParseTildeRange(String range, String expectedString) {
+        assertThat(tildeProcessor.tryProcess(range)).isEqualTo(expectedString);
+    }
+
+    static Stream<Arguments> shouldParseTildeRange() {
+        return Stream.of(
+                arguments("~1.2.3", ">=1.2.3 <1.3.0"),
+                arguments("~1.2", ">=1.2.0 <1.3.0"),
+                arguments("~1", ">=1.0.0 <2.0.0"),
+                arguments("~1.2.3-alpha", ">=1.2.3-alpha <1.3.0"),
+                arguments("INVALID", "INVALID")
+        );
+    }
+}

--- a/src/test/java/org/semver4j/internal/range/processor/TildeProcessorTest.java
+++ b/src/test/java/org/semver4j/internal/range/processor/TildeProcessorTest.java
@@ -24,7 +24,7 @@ class TildeProcessorTest {
                 arguments("~1.2", ">=1.2.0 <1.3.0"),
                 arguments("~1", ">=1.0.0 <2.0.0"),
                 arguments("~1.2.3-alpha", ">=1.2.3-alpha <1.3.0"),
-                arguments("INVALID", "INVALID")
+                arguments("INVALID", null)
         );
     }
 }

--- a/src/test/java/org/semver4j/internal/range/processor/XRangeProcessorTest.java
+++ b/src/test/java/org/semver4j/internal/range/processor/XRangeProcessorTest.java
@@ -1,0 +1,36 @@
+package org.semver4j.internal.range.processor;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class XRangeProcessorTest {
+    private final XRangeProcessor xRangeProcessor = new XRangeProcessor();
+
+    @ParameterizedTest
+    @MethodSource
+    void shouldParseXRange(String range, String expectedString) {
+        assertThat(xRangeProcessor.tryProcess(range)).isEqualTo(expectedString);
+    }
+
+    static Stream<Arguments> shouldParseXRange() {
+        return Stream.of(
+                arguments(">1.X.X", ">=2.0.0"),
+                arguments(">1.2.X", ">=1.3.0"),
+                arguments("<=1.X.X", "<2.0.0"),
+                arguments("<=1.2.X", "<1.3.0"),
+                arguments(">=1.2.X", ">=1.2.0"),
+                arguments(">=1.X.X", ">=1.0.0"),
+                arguments("1.X", ">=1.0.0 <2.0.0"),
+                arguments("1.2.X", ">=1.2.0 <1.3.0"),
+                arguments("=1.2.X", ">=1.2.0 <1.3.0"),
+                arguments(">=1.2.3 <2.0.0", ">=1.2.3 <2.0.0"),
+                arguments("INVALID", "INVALID")
+        );
+    }
+}

--- a/src/test/java/org/semver4j/internal/range/processor/XRangeProcessorTest.java
+++ b/src/test/java/org/semver4j/internal/range/processor/XRangeProcessorTest.java
@@ -30,7 +30,7 @@ class XRangeProcessorTest {
                 arguments("1.2.X", ">=1.2.0 <1.3.0"),
                 arguments("=1.2.X", ">=1.2.0 <1.3.0"),
                 arguments(">=1.2.3 <2.0.0", ">=1.2.3 <2.0.0"),
-                arguments("INVALID", "INVALID")
+                arguments("INVALID", null)
         );
     }
 }


### PR DESCRIPTION
`latest` and `latest.integration` processing have been moved into IvyProcessor such that all range string processors should now be self-contained

This fixes #257 