### PR TITLE
Fix OOBE, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,42 +9,43 @@
 
 ---
 
-> ### This is an active copy of great [semver4j](https://github.com/vdurmont/semver4j) library created by [@vdurmont](https://github.com/vdurmont), which is no longer maintained 😭
+> ### This is an active copy of the great [semver4j](https://github.com/vdurmont/semver4j) library created by [@vdurmont](https://github.com/vdurmont), no longer maintained 😭
 
 ---
 
 **Semver4j** is a lightweight Java library that helps you to handle versions.
 It follows the rules of the [semantic versioning](http://semver.org) specification.
 
-It also provides several range checking support: [node-semver](https://github.com/npm/node-semver),
+It also provides support for several range checking: [node-semver](https://github.com/npm/node-semver),
 [CocoaPods](https://guides.cocoapods.org/using/the-podfile.html)
 and [Ivy](https://ant.apache.org/ivy/history/latest-milestone/settings/version-matchers.html).
 
 ## Table of Contents
 
 <!-- TOC -->
-
-* [Installation](#installation)
+* [Semver4j](#semver4j)
+  * [Table of Contents](#table-of-contents)
+  * [Installation](#installation)
     * [Using Maven](#using-maven)
     * [Using Gradle](#using-gradle)
-* [Usage](#usage)
+          * [Version `v1.0.x` references to original library version `v3.1.0` in source repository.](#version-v10x-references-to-original-library-version-v310-in-source-repository)
+  * [Usage](#usage)
     * [What is a version?](#what-is-a-version)
     * [The `Semver` object](#the-semver-object)
-        * [Using constructor](#using-constructor)
-        * [Using `Semver.parse()` method](#using-semverparse-method)
-        * [Using `Semver.coerce()` method](#using-semvercoerce-method)
+      * [Using constructor](#using-constructor)
+      * [Using `Semver.parse()` method](#using-semverparse-method)
+      * [Using `Semver.coerce()` method](#using-semvercoerce-method)
     * [Is the version stable?](#is-the-version-stable)
     * [Comparing the versions](#comparing-the-versions)
     * [Versions diffs](#versions-diffs)
     * [Ranges](#ranges)
-        * [External](#external)
-        * [Internal](#internal)
+      * [External](#external)
+      * [Internal](#internal)
     * [Modifying the version](#modifying-the-version)
     * [Builder](#builder)
     * [Formatting](#formatting)
-* [Contributing](#contributing)
-* [Thanks](#thanks)
-
+  * [Contributing](#contributing)
+  * [Thanks](#thanks)
 <!-- TOC -->
 
 ## Installation
@@ -54,7 +55,6 @@ Add the dependency to your project:
 ### Using Maven
 
 ```xml
-
 <dependency>
     <groupId>org.semver4j</groupId>
     <artifactId>semver4j</artifactId>
@@ -195,7 +195,7 @@ version.diff("1.2.3-beta.4+sha32iddfu987");  // BUILD
 
 If you want to check if a version satisfies a range, use the `satisfies()` method.
 
-`Semver4j` can interpret following range implementations:
+`Semver4j` can interpret the following range implementations:
 
 - [NPM](https://github.com/npm/node-semver)
     - [Primitive ranges](https://github.com/npm/node-semver#ranges) `<`, `<=`, `>`, `>=` and `=`
@@ -276,4 +276,3 @@ If you have any suggestion about new features, you can **open an issue**.
 ## Thanks
 
 Logo created by Tomek Babik [@tomekbbk](https://github.com/tomekbbk).
-

--- a/src/main/java/org/semver4j/internal/Comparator.java
+++ b/src/main/java/org/semver4j/internal/Comparator.java
@@ -77,7 +77,7 @@ public class Comparator {
     }
 
     private static int compareIdentifiers(@NotNull final String a, @NotNull final String b) {
-        // Only attempt to parse fully-numeric string sequences so that we can avoid
+        // Only attempt to parse fully numeric string sequences so that we can avoid
         // raising a costly exception
         if (a.matches(ALL_DIGITS) && b.matches(ALL_DIGITS)) {
             long aAsLong = Long.parseLong(a);
@@ -105,6 +105,9 @@ public class Comparator {
     private static Integer checkAlphanumericPrerelease(@NotNull final String a, @NotNull final String b) {
         String[] tokenArrA = a.split(TRAILING_DIGITS_EXTRACT);
         String[] tokenArrB = b.split(TRAILING_DIGITS_EXTRACT);
+        if (tokenArrA.length != tokenArrB.length) {
+            return tokenArrA.length - tokenArrB.length;
+        }
         if (tokenArrA[0].equals(tokenArrB[0])) {
             String[] leadingDigitsArrA = tokenArrA[1].split(LEADING_DIGITS_EXTRACT);
             String[] leadingDigitsArrB = tokenArrB[1].split(LEADING_DIGITS_EXTRACT);

--- a/src/test/java/org/semver4j/internal/ComparatorTest.java
+++ b/src/test/java/org/semver4j/internal/ComparatorTest.java
@@ -1,0 +1,20 @@
+package org.semver4j.internal;
+
+import org.junit.jupiter.api.Test;
+import org.semver4j.Semver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ComparatorTest {
+    @Test
+    void shouldUnevenComparisonNotCrashAndBeCorrect() {
+        Semver semver1 = Semver.coerce("4.0.0-beta.9-macro");
+        Semver semver2 = Semver.coerce("4.0.0-beta.9-macro2");
+
+        assertThat(semver1).isNotNull();
+        assertThat(semver2).isNotNull();
+
+        assertThat(Comparator.compareTo(semver1, semver2)).isNegative();
+        assertThat(Comparator.compareTo(semver2, semver1)).isPositive();
+    }
+}


### PR DESCRIPTION
Fixes #264

Return `a.length - b.length` if the regex arrays don't have the same length. This kind of OOB issue seems impossible elsewhere in the file, so it should be fine.

I also updated the README to fix typos and apply the changes IJ suggested, including a TOC fix.