### PR TITLE
Add include prerelease flag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
             <!-- JUnit 5 requires Surefire version 2.22.0 or higher -->
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.4.0</version>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
             <!-- JUnit 5 requires Surefire version 2.22.0 or higher -->
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.0.0</version>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
             <!-- JUnit 5 requires Surefire version 2.22.0 or higher -->
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>2.22.2</version>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
             <!-- JUnit 5 requires Surefire version 2.22.0 or higher -->
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.3</version>
+                <version>2.22.2</version>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/src/main/java/org/semver4j/RangesExpression.java
+++ b/src/main/java/org/semver4j/RangesExpression.java
@@ -27,7 +27,7 @@ import static org.semver4j.Range.RangeOperator.*;
 @NullMarked
 @SuppressWarnings("checkstyle:DeclarationOrder")
 public class RangesExpression {
-    private final RangesList rangesList = new RangesList();
+    private final RangesList rangesList = new RangesList(false);
 
     private final List<Range> andOperationRanges = new ArrayList<>();
 

--- a/src/main/java/org/semver4j/RangesList.java
+++ b/src/main/java/org/semver4j/RangesList.java
@@ -45,7 +45,7 @@ public class RangesList {
 
     private final List<List<Range>> rangesList = new ArrayList<>();
 
-    private boolean includePrerelease = false;
+    private boolean includePrerelease;
 
     /**
      * Add ranges to ranges list.

--- a/src/main/java/org/semver4j/RangesList.java
+++ b/src/main/java/org/semver4j/RangesList.java
@@ -45,6 +45,8 @@ public class RangesList {
 
     private final List<List<Range>> rangesList = new ArrayList<>();
 
+    private boolean includePrerelease = false;
+
     /**
      * Add ranges to ranges list.
      */
@@ -63,6 +65,16 @@ public class RangesList {
     }
 
     /**
+     * Configures the RangesList to include always include prereleases when evaluating range satisfacion.
+     * Returns the same RangesList.
+     */
+    @NotNull
+    public RangesList includePrerelease() {
+        this.includePrerelease = true;
+        return this;
+    }
+
+    /**
      * Check whether this ranges list is satisfied by any version.
      */
     public boolean isSatisfiedByAny() {
@@ -76,7 +88,7 @@ public class RangesList {
      */
     public boolean isSatisfiedBy(final Semver version) {
         return rangesList.stream()
-            .anyMatch(ranges -> isSingleSetOfRangesIsSatisfied(ranges, version));
+                .anyMatch(ranges -> isSingleSetOfRangesIsSatisfied(ranges, version));
     }
 
     @Override
@@ -99,14 +111,14 @@ public class RangesList {
         return format(Locale.ROOT, "(%s)", representation);
     }
 
-    private static boolean isSingleSetOfRangesIsSatisfied(final List<Range> ranges, final Semver version) {
+    private boolean isSingleSetOfRangesIsSatisfied(final List<Range> ranges, final Semver version) {
         for (Range range : ranges) {
             if (!range.isSatisfiedBy(version)) {
                 return false;
             }
         }
 
-        if (!version.getPreRelease().isEmpty()) {
+        if (!version.getPreRelease().isEmpty() && !this.includePrerelease) {
             for (Range range : ranges) {
                 Semver rangeSemver = range.getRangeVersion();
                 List<String> preRelease = rangeSemver.getPreRelease();

--- a/src/main/java/org/semver4j/RangesList.java
+++ b/src/main/java/org/semver4j/RangesList.java
@@ -1,9 +1,10 @@
 package org.semver4j;
 
+import org.jspecify.annotations.NullMarked;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import org.jspecify.annotations.NullMarked;
 
 import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
@@ -45,7 +46,11 @@ public class RangesList {
 
     private final List<List<Range>> rangesList = new ArrayList<>();
 
-    private boolean includePrerelease;
+    private final boolean includePrerelease;
+
+    public RangesList(boolean includePrerelease) {
+        this.includePrerelease = includePrerelease;
+    }
 
     /**
      * Add ranges to ranges list.
@@ -65,22 +70,12 @@ public class RangesList {
     }
 
     /**
-     * Configures the RangesList to include always include prereleases when evaluating range satisfacion.
-     * Returns the same RangesList.
-     */
-    @NotNull
-    public RangesList includePrerelease() {
-        this.includePrerelease = true;
-        return this;
-    }
-
-    /**
      * Check whether this ranges list is satisfied by any version.
      */
     public boolean isSatisfiedByAny() {
         return rangesList.stream()
-            .flatMap(List::stream)
-            .allMatch(Range::isSatisfiedByAny);
+                .flatMap(List::stream)
+                .allMatch(Range::isSatisfiedByAny);
     }
 
     /**
@@ -94,15 +89,15 @@ public class RangesList {
     @Override
     public String toString() {
         return rangesList.stream()
-            .map(RangesList::formatRanges)
-            .collect(joining(OR_JOINER))
-            .replaceAll("^\\(([^()]+)\\)$", "$1");
+                .map(RangesList::formatRanges)
+                .collect(joining(OR_JOINER))
+                .replaceAll("^\\(([^()]+)\\)$", "$1");
     }
 
     private static String formatRanges(final List<Range> ranges) {
         String representation = ranges.stream()
-            .map(Range::toString)
-            .collect(joining(AND_JOINER));
+                .map(Range::toString)
+                .collect(joining(AND_JOINER));
 
         if (ranges.size() < 2) {
             return representation;
@@ -118,14 +113,14 @@ public class RangesList {
             }
         }
 
-        if (!version.getPreRelease().isEmpty() && !this.includePrerelease) {
+        if (!version.getPreRelease().isEmpty() && !includePrerelease) {
             for (Range range : ranges) {
                 Semver rangeSemver = range.getRangeVersion();
-                List<String> preRelease = rangeSemver.getPreRelease();
-                if (preRelease.size() > 0) {
+                List<String> prerelease = rangeSemver.getPreRelease();
+                if (prerelease.size() > 0) {
                     if (version.getMajor() == rangeSemver.getMajor() &&
-                        version.getMinor() == rangeSemver.getMinor() &&
-                        version.getPatch() == rangeSemver.getPatch()) {
+                            version.getMinor() == rangeSemver.getMinor() &&
+                            version.getPatch() == rangeSemver.getPatch()) {
                         return true;
                     }
                 }

--- a/src/main/java/org/semver4j/RangesListFactory.java
+++ b/src/main/java/org/semver4j/RangesListFactory.java
@@ -8,7 +8,11 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 public class RangesListFactory {
     public static RangesList create(final String range) {
-        return new RangesString().get(range);
+        return create(range, false);
+    }
+
+    public static RangesList create(final String range, boolean includePrerelease) {
+        return new RangesString().get(range, includePrerelease);
     }
 
     /**

--- a/src/main/java/org/semver4j/RangesListFactory.java
+++ b/src/main/java/org/semver4j/RangesListFactory.java
@@ -7,12 +7,15 @@ import org.jspecify.annotations.NullMarked;
  */
 @NullMarked
 public class RangesListFactory {
-    public static RangesList create(final String range) {
-        return create(range, false);
-    }
-
+    /**
+     * @since 5.8.0
+     */
     public static RangesList create(final String range, boolean includePrerelease) {
         return new RangesString().get(range, includePrerelease);
+    }
+
+    public static RangesList create(final String range) {
+        return create(range, false);
     }
 
     /**

--- a/src/main/java/org/semver4j/RangesString.java
+++ b/src/main/java/org/semver4j/RangesString.java
@@ -29,14 +29,21 @@ class RangesString {
             .addProcessor(new TildeProcessor())
             .addProcessor(new XRangeProcessor());
 
-    RangesList get(String range) {
-        RangesList rangesList = new RangesList();
+    private static final RangeProcessorPipeline rangeProcessorPipelineWithPrerelease = startWith(new AllVersionsProcessor())
+            .addProcessor(new IvyProcessor())
+            .addProcessor(new HyphenProcessor())
+            .addProcessor(new CaretProcessor())
+            .addProcessor(new TildeProcessor())
+            .addProcessor(new XRangeProcessor())
+            .includePrerelease();
 
+    RangesList get(String range, boolean includePrerelease) {
+        RangesList rangesList = new RangesList();
         range = range.trim();
         String[] rangeSections = range.split("\\|\\|");
         for (String rangeSection : rangeSections) {
             rangeSection = stripWhitespacesBetweenRangeOperator(rangeSection);
-            rangeSection = applyProcessors(rangeSection);
+            rangeSection = includePrerelease ? rangeProcessorPipelineWithPrerelease.process(rangeSection) : rangeProcessorPipeline.process(rangeSection);
 
             List<Range> ranges = addRanges(rangeSection);
             rangesList.add(ranges);
@@ -48,10 +55,6 @@ class RangesString {
     private static String stripWhitespacesBetweenRangeOperator(final String rangeSection) {
         Matcher matcher = splitterPattern.matcher(rangeSection);
         return matcher.replaceAll("$1$2").trim();
-    }
-
-    private static String applyProcessors(final String range) {
-        return rangeProcessorPipeline.process(range);
     }
 
     private static List<Range> addRanges(final String range) {

--- a/src/main/java/org/semver4j/RangesString.java
+++ b/src/main/java/org/semver4j/RangesString.java
@@ -2,12 +2,7 @@ package org.semver4j;
 
 import org.jspecify.annotations.NullMarked;
 import org.semver4j.internal.range.RangeProcessorPipeline;
-import org.semver4j.internal.range.processor.AllVersionsProcessor;
-import org.semver4j.internal.range.processor.CaretProcessor;
-import org.semver4j.internal.range.processor.HyphenProcessor;
-import org.semver4j.internal.range.processor.IvyProcessor;
-import org.semver4j.internal.range.processor.TildeProcessor;
-import org.semver4j.internal.range.processor.XRangeProcessor;
+import org.semver4j.internal.range.processor.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,21 +24,13 @@ class RangesString {
             .addProcessor(new TildeProcessor())
             .addProcessor(new XRangeProcessor());
 
-    private static final RangeProcessorPipeline rangeProcessorPipelineWithPrerelease = startWith(new AllVersionsProcessor())
-            .addProcessor(new IvyProcessor())
-            .addProcessor(new HyphenProcessor())
-            .addProcessor(new CaretProcessor())
-            .addProcessor(new TildeProcessor())
-            .addProcessor(new XRangeProcessor())
-            .includePrerelease();
-
     RangesList get(String range, boolean includePrerelease) {
-        RangesList rangesList = new RangesList();
+        RangesList rangesList = new RangesList(includePrerelease);
         range = range.trim();
         String[] rangeSections = range.split("\\|\\|");
         for (String rangeSection : rangeSections) {
             rangeSection = stripWhitespacesBetweenRangeOperator(rangeSection);
-            rangeSection = includePrerelease ? rangeProcessorPipelineWithPrerelease.process(rangeSection) : rangeProcessorPipeline.process(rangeSection);
+            rangeSection = applyProcessors(rangeSection, includePrerelease);
 
             List<Range> ranges = addRanges(rangeSection);
             rangesList.add(ranges);
@@ -55,6 +42,10 @@ class RangesString {
     private static String stripWhitespacesBetweenRangeOperator(final String rangeSection) {
         Matcher matcher = splitterPattern.matcher(rangeSection);
         return matcher.replaceAll("$1$2").trim();
+    }
+
+    private static String applyProcessors(final String range, boolean includePrerelease) {
+        return rangeProcessorPipeline.process(range, includePrerelease);
     }
 
     private static List<Range> addRanges(final String range) {

--- a/src/main/java/org/semver4j/Semver.java
+++ b/src/main/java/org/semver4j/Semver.java
@@ -22,8 +22,6 @@ import static java.util.Objects.requireNonNull;
 public class Semver implements Comparable<Semver> {
     public static final Semver ZERO = new Semver("0.0.0");
 
-    public static final String LOWEST_PRERELEASE = "-0";
-
     private final String originalVersion;
 
     private final int major;
@@ -520,11 +518,18 @@ public class Semver implements Comparable<Semver> {
         return satisfies(range, false);
     }
 
+    /**
+     * Check if the version satisfies a range with an option to include prereleases.
+     *
+     * @param range             version range expression to check against
+     * @param includePrerelease whether to include prereleases in the check
+     * @return {@code true} if the version satisfies the range, {@code false} otherwise
+     * @see #satisfies(String)
+     * @see #satisfies(RangesList)
+     * @since 5.8.0
+     */
     public boolean satisfies(final String range, boolean includePrerelease) {
         RangesList rangesList = RangesListFactory.create(range, includePrerelease);
-        if (includePrerelease) {
-            rangesList.includePrerelease();
-        }
         return satisfies(rangesList);
     }
 

--- a/src/main/java/org/semver4j/Semver.java
+++ b/src/main/java/org/semver4j/Semver.java
@@ -22,6 +22,8 @@ import static java.util.Objects.requireNonNull;
 public class Semver implements Comparable<Semver> {
     public static final Semver ZERO = new Semver("0.0.0");
 
+    public static final String LOWEST_PRERELEASE = "-0";
+
     private final String originalVersion;
 
     private final int major;
@@ -507,7 +509,7 @@ public class Semver implements Comparable<Semver> {
     }
 
     /**
-     * Check if the version satisfies a range.
+     * Check if the version satisfies a range. Defaults to not including prereleases.
      *
      * @param range range
      * @return {@code true} if the version satisfies the range, {@code false} otherwise
@@ -515,7 +517,14 @@ public class Semver implements Comparable<Semver> {
      * @see #satisfies(RangesExpression)
      */
     public boolean satisfies(final String range) {
-        RangesList rangesList = RangesListFactory.create(range);
+        return satisfies(range, false);
+    }
+
+    public boolean satisfies(final String range, boolean includePrerelease) {
+        RangesList rangesList = RangesListFactory.create(range, includePrerelease);
+        if(includePrerelease) {
+            rangesList.includePrerelease();
+        }
         return satisfies(rangesList);
     }
 

--- a/src/main/java/org/semver4j/Semver.java
+++ b/src/main/java/org/semver4j/Semver.java
@@ -2,8 +2,8 @@ package org.semver4j;
 
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
-import org.semver4j.internal.Comparator;
 import org.semver4j.internal.*;
+import org.semver4j.internal.Comparator;
 import org.semver4j.internal.StrictParser.Version;
 
 import java.util.*;
@@ -522,7 +522,7 @@ public class Semver implements Comparable<Semver> {
 
     public boolean satisfies(final String range, boolean includePrerelease) {
         RangesList rangesList = RangesListFactory.create(range, includePrerelease);
-        if(includePrerelease) {
+        if (includePrerelease) {
             rangesList.includePrerelease();
         }
         return satisfies(rangesList);

--- a/src/main/java/org/semver4j/internal/range/RangeProcessorPipeline.java
+++ b/src/main/java/org/semver4j/internal/range/RangeProcessorPipeline.java
@@ -18,6 +18,11 @@ public class RangeProcessorPipeline {
         return this;
     }
 
+    public RangeProcessorPipeline includePrerelease() {
+        processors.forEach(Processor::includePrerelease);
+        return this;
+    }
+
     public String process(final String range) {
         for (Processor processor : processors) {
             String processedRange = processor.tryProcess(range);

--- a/src/main/java/org/semver4j/internal/range/RangeProcessorPipeline.java
+++ b/src/main/java/org/semver4j/internal/range/RangeProcessorPipeline.java
@@ -4,10 +4,11 @@ import org.jspecify.annotations.NullMarked;
 import org.semver4j.internal.range.processor.Processor;
 
 import java.util.ArrayList;
+import java.util.List;
 
 @NullMarked
 public class RangeProcessorPipeline {
-    private final ArrayList<Processor> processors = new ArrayList<>();
+    private final List<Processor> processors = new ArrayList<>();
 
     public RangeProcessorPipeline(final Processor currentProcessor) {
         this.processors.add(currentProcessor);
@@ -18,14 +19,9 @@ public class RangeProcessorPipeline {
         return this;
     }
 
-    public RangeProcessorPipeline includePrerelease() {
-        processors.forEach(Processor::includePrerelease);
-        return this;
-    }
-
-    public String process(final String range) {
+    public String process(final String range, boolean includePrerelease) {
         for (Processor processor : processors) {
-            String processedRange = processor.tryProcess(range);
+            String processedRange = processor.process(range, includePrerelease);
             if (processedRange != null) {
                 return processedRange;
             }

--- a/src/main/java/org/semver4j/internal/range/processor/AllVersionsProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/AllVersionsProcessor.java
@@ -11,6 +11,12 @@ import org.jspecify.annotations.Nullable;
  *     <li>{@code *} to {@code ≥0.0.0}</li>
  *     <li>An empty string to {@code ≥0.0.0}</li>
  * </ul>
+ *
+ * If the prerelease flag is set to true, will translate:
+ * <ul>
+ *     <li>{@code *} to {@code ≥0.0.0-0}</li>
+ *     <li>An empty string to {@code ≥0.0.0-0}</li>
+ * </ul>
  */
 @NullMarked
 public class AllVersionsProcessor extends Processor {

--- a/src/main/java/org/semver4j/internal/range/processor/AllVersionsProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/AllVersionsProcessor.java
@@ -2,12 +2,6 @@ package org.semver4j.internal.range.processor;
 
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
-import org.semver4j.Semver;
-
-import java.util.Locale;
-
-import static java.lang.String.format;
-import static org.semver4j.Range.RangeOperator.GTE;
 
 /**
  * <p>Processor for translating {@code *} and empty strings into a classic range.</p>
@@ -19,12 +13,12 @@ import static org.semver4j.Range.RangeOperator.GTE;
  * </ul>
  */
 @NullMarked
-public class AllVersionsProcessor implements Processor {
+public class AllVersionsProcessor extends Processor {
     @Override
     @Nullable
     public String tryProcess(String range) {
         if (range.equals("*") || range.isEmpty()) {
-            return format(Locale.ROOT, "%s%s", GTE.asString(), Semver.ZERO);
+            return this.getIncludePrerelease() ? RangesUtils.ALL_RANGE_WITH_PRERELEASE : RangesUtils.ALL_RANGE;
         }
         return null;
     }

--- a/src/main/java/org/semver4j/internal/range/processor/AllVersionsProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/AllVersionsProcessor.java
@@ -11,7 +11,7 @@ import org.jspecify.annotations.Nullable;
  *     <li>{@code *} to {@code ≥0.0.0}</li>
  *     <li>An empty string to {@code ≥0.0.0}</li>
  * </ul>
- *
+ * <p>
  * If the prerelease flag is set to true, will translate:
  * <ul>
  *     <li>{@code *} to {@code ≥0.0.0-0}</li>
@@ -19,12 +19,12 @@ import org.jspecify.annotations.Nullable;
  * </ul>
  */
 @NullMarked
-public class AllVersionsProcessor extends Processor {
+public class AllVersionsProcessor implements Processor {
     @Override
     @Nullable
-    public String tryProcess(String range) {
+    public String process(String range, boolean includePrerelease) {
         if (range.equals("*") || range.isEmpty()) {
-            return this.getIncludePrerelease() ? RangesUtils.ALL_RANGE_WITH_PRERELEASE : RangesUtils.ALL_RANGE;
+            return includePrerelease ? RangesUtils.ALL_RANGE_WITH_PRERELEASE : RangesUtils.ALL_RANGE;
         }
         return null;
     }

--- a/src/main/java/org/semver4j/internal/range/processor/CaretProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/CaretProcessor.java
@@ -2,7 +2,6 @@ package org.semver4j.internal.range.processor;
 
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
-import org.semver4j.Semver;
 
 import java.util.Locale;
 import java.util.regex.Matcher;
@@ -13,9 +12,7 @@ import static java.util.regex.Pattern.compile;
 import static org.semver4j.Range.RangeOperator.GTE;
 import static org.semver4j.Range.RangeOperator.LT;
 import static org.semver4j.internal.Tokenizers.CARET;
-import static org.semver4j.internal.range.processor.RangesUtils.isNotBlank;
-import static org.semver4j.internal.range.processor.RangesUtils.isX;
-import static org.semver4j.internal.range.processor.RangesUtils.parseIntWithXSupport;
+import static org.semver4j.internal.range.processor.RangesUtils.*;
 
 /**
  * <p>Processor for translate <a href="https://github.com/npm/node-semver#caret-ranges-123-025-004">caret ranges</a>
@@ -28,7 +25,7 @@ import static org.semver4j.internal.range.processor.RangesUtils.parseIntWithXSup
  *     <li>{@code ^1} to {@code ≥1.0.0 < 2.0.0}</li>
  *     <li>{@code ^0.2.3} to {@code ≥0.2.3 <0.3.0}</li>
  * </ul>
- *
+ * <p>
  * If the prerelease flag is set to true, will translate:
  * <ul>
  *     <li>{@code ^1.2.3} to {@code ≥1.2.3 <2.0.0-0}</li>

--- a/src/main/java/org/semver4j/internal/range/processor/CaretProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/CaretProcessor.java
@@ -38,11 +38,12 @@ import static org.semver4j.internal.range.processor.RangesUtils.parseIntWithXSup
  * </ul>
  */
 @NullMarked
-public class CaretProcessor extends Processor {
+public class CaretProcessor implements Processor {
     private static final Pattern pattern = compile(CARET);
 
     @Override
-    public @Nullable String tryProcess(String range) {
+    @Nullable
+    public String process(String range, boolean includePrerelease) {
         Matcher matcher = pattern.matcher(range);
 
         if (!matcher.matches()) {
@@ -59,44 +60,44 @@ public class CaretProcessor extends Processor {
 
         String from;
         String to;
-        String pr = this.getIncludePrerelease() ? Semver.LOWEST_PRERELEASE : "";
+        String prerelease = includePrerelease ? Processor.LOWEST_PRERELEASE : "";
 
         if (minorIsX) {
-            from = format(Locale.ROOT, "%s%d.0.0%s", GTE.asString(), major, pr);
-            to = format(Locale.ROOT, "%s%d.0.0%s", LT.asString(), (major + 1), pr);
+            from = format(Locale.ROOT, "%s%d.0.0%s", GTE.asString(), major, prerelease);
+            to = format(Locale.ROOT, "%s%d.0.0%s", LT.asString(), (major + 1), prerelease);
         } else if (patchIsX) {
             if (major == 0) {
-                from = format(Locale.ROOT, "%s%d.%d.0%s", GTE.asString(), major, minor, pr);
-                to = format(Locale.ROOT, "%s%d.%d.0%s", LT.asString(), major, (minor + 1), pr);
+                from = format(Locale.ROOT, "%s%d.%d.0%s", GTE.asString(), major, minor, prerelease);
+                to = format(Locale.ROOT, "%s%d.%d.0%s", LT.asString(), major, (minor + 1), prerelease);
             } else {
-                from = format(Locale.ROOT, "%s%d.%d.0%s", GTE.asString(), major, minor, pr);
-                to = format(Locale.ROOT, "%s%d.0.0%s", LT.asString(), (major + 1), pr);
+                from = format(Locale.ROOT, "%s%d.%d.0%s", GTE.asString(), major, minor, prerelease);
+                to = format(Locale.ROOT, "%s%d.0.0%s", LT.asString(), (major + 1), prerelease);
             }
         } else if (isNotBlank(preRelease)) {
             if (major == 0) {
                 if (minor == 0) {
                     from = format(Locale.ROOT, "%s%d.%d.%d-%s", GTE.asString(), major, minor, path, preRelease);
-                    to = format(Locale.ROOT, "%s%d.%d.%d%s", LT.asString(), major, minor, (path + 1), pr);
+                    to = format(Locale.ROOT, "%s%d.%d.%d%s", LT.asString(), major, minor, (path + 1), prerelease);
                 } else {
                     from = format(Locale.ROOT, "%s%d.%d.%d-%s", GTE.asString(), major, minor, path, preRelease);
-                    to = format(Locale.ROOT, "%s%d.%d.0%s", LT.asString(), major, (minor + 1), pr);
+                    to = format(Locale.ROOT, "%s%d.%d.0%s", LT.asString(), major, (minor + 1), prerelease);
                 }
             } else {
                 from = format(Locale.ROOT, "%s%d.%d.%d-%s", GTE.asString(), major, minor, path, preRelease);
-                to = format(Locale.ROOT, "%s%d.0.0%s", LT.asString(), (major + 1), pr);
+                to = format(Locale.ROOT, "%s%d.0.0%s", LT.asString(), (major + 1), prerelease);
             }
         } else {
             if (major == 0) {
                 if (minor == 0) {
                     from = format(Locale.ROOT, "%s%d.%d.%d", GTE.asString(), major, minor, path);
-                    to = format(Locale.ROOT, "%s%d.%d.%d%s", LT.asString(), major, minor, (path + 1), pr);
+                    to = format(Locale.ROOT, "%s%d.%d.%d%s", LT.asString(), major, minor, (path + 1), prerelease);
                 } else {
                     from = format(Locale.ROOT, "%s%d.%d.%d", GTE.asString(), major, minor, path);
-                    to = format(Locale.ROOT, "%s%d.%d.0%s", LT.asString(), major, (minor + 1), pr);
+                    to = format(Locale.ROOT, "%s%d.%d.0%s", LT.asString(), major, (minor + 1), prerelease);
                 }
             } else {
                 from = format(Locale.ROOT, "%s%d.%d.%d", GTE.asString(), major, minor, path);
-                to = format(Locale.ROOT, "%s%d.0.0%s", LT.asString(), (major + 1), pr);
+                to = format(Locale.ROOT, "%s%d.0.0%s", LT.asString(), (major + 1), prerelease);
             }
         }
 

--- a/src/main/java/org/semver4j/internal/range/processor/CaretProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/CaretProcessor.java
@@ -24,7 +24,17 @@ import static org.semver4j.internal.range.processor.RangesUtils.parseIntWithXSup
  * Translates:
  * <ul>
  *     <li>{@code ^1.2.3} to {@code ≥1.2.3 <2.0.0}</li>
+ *     <li>{@code ^1.2} to {@code ≥1.2.0 <2.0.0}</li>
+ *     <li>{@code ^1} to {@code ≥1.0.0 < 2.0.0}</li>
  *     <li>{@code ^0.2.3} to {@code ≥0.2.3 <0.3.0}</li>
+ * </ul>
+ *
+ * If the prerelease flag is set to true, will translate:
+ * <ul>
+ *     <li>{@code ^1.2.3} to {@code ≥1.2.3 <2.0.0-0}</li>
+ *     <li>{@code ^1.2} to {@code ≥1.2.0-0 <2.0.0-0}</li>
+ *     <li>{@code ^1} to {@code ≥1.0.0-0 < 2.0.0-0}</li>
+ *     <li>{@code ^0.2.3} to {@code ≥0.2.3 <0.3.0-0}</li>
  * </ul>
  */
 @NullMarked

--- a/src/main/java/org/semver4j/internal/range/processor/CaretProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/CaretProcessor.java
@@ -2,6 +2,7 @@ package org.semver4j.internal.range.processor;
 
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+import org.semver4j.Semver;
 
 import java.util.Locale;
 import java.util.regex.Matcher;
@@ -27,7 +28,7 @@ import static org.semver4j.internal.range.processor.RangesUtils.parseIntWithXSup
  * </ul>
  */
 @NullMarked
-public class CaretProcessor implements Processor {
+public class CaretProcessor extends Processor {
     private static final Pattern pattern = compile(CARET);
 
     @Override
@@ -48,43 +49,44 @@ public class CaretProcessor implements Processor {
 
         String from;
         String to;
+        String pr = this.getIncludePrerelease() ? Semver.LOWEST_PRERELEASE : "";
 
         if (minorIsX) {
-            from = format(Locale.ROOT, "%s%d.0.0", GTE.asString(), major);
-            to = format(Locale.ROOT, "%s%d.0.0", LT.asString(), (major + 1));
+            from = format(Locale.ROOT, "%s%d.0.0%s", GTE.asString(), major, pr);
+            to = format(Locale.ROOT, "%s%d.0.0%s", LT.asString(), (major + 1), pr);
         } else if (patchIsX) {
             if (major == 0) {
-                from = format(Locale.ROOT, "%s%d.%d.0", GTE.asString(), major, minor);
-                to = format(Locale.ROOT, "%s%d.%d.0", LT.asString(), major, (minor + 1));
+                from = format(Locale.ROOT, "%s%d.%d.0%s", GTE.asString(), major, minor, pr);
+                to = format(Locale.ROOT, "%s%d.%d.0%s", LT.asString(), major, (minor + 1), pr);
             } else {
-                from = format(Locale.ROOT, "%s%d.%d.0", GTE.asString(), major, minor);
-                to = format(Locale.ROOT, "%s%d.0.0", LT.asString(), (major + 1));
+                from = format(Locale.ROOT, "%s%d.%d.0%s", GTE.asString(), major, minor, pr);
+                to = format(Locale.ROOT, "%s%d.0.0%s", LT.asString(), (major + 1), pr);
             }
         } else if (isNotBlank(preRelease)) {
             if (major == 0) {
                 if (minor == 0) {
                     from = format(Locale.ROOT, "%s%d.%d.%d-%s", GTE.asString(), major, minor, path, preRelease);
-                    to = format(Locale.ROOT, "%s%d.%d.%d", LT.asString(), major, minor, (path + 1));
+                    to = format(Locale.ROOT, "%s%d.%d.%d%s", LT.asString(), major, minor, (path + 1), pr);
                 } else {
                     from = format(Locale.ROOT, "%s%d.%d.%d-%s", GTE.asString(), major, minor, path, preRelease);
-                    to = format(Locale.ROOT, "%s%d.%d.0", LT.asString(), major, (minor + 1));
+                    to = format(Locale.ROOT, "%s%d.%d.0%s", LT.asString(), major, (minor + 1), pr);
                 }
             } else {
                 from = format(Locale.ROOT, "%s%d.%d.%d-%s", GTE.asString(), major, minor, path, preRelease);
-                to = format(Locale.ROOT, "%s%d.0.0", LT.asString(), (major + 1));
+                to = format(Locale.ROOT, "%s%d.0.0%s", LT.asString(), (major + 1), pr);
             }
         } else {
             if (major == 0) {
                 if (minor == 0) {
-                    from = format(Locale.ROOT, "%s%d.%d.%d", GTE.asString(), major, minor, path);
-                    to = format(Locale.ROOT, "%s%d.%d.%d", LT.asString(), major, minor, (path + 1));
+                    from = format(Locale.ROOT, "%s%d.%d.%d%s", GTE.asString(), major, minor, path, pr);
+                    to = format(Locale.ROOT, "%s%d.%d.%d%s", LT.asString(), major, minor, (path + 1), pr);
                 } else {
-                    from = format(Locale.ROOT, "%s%d.%d.%d", GTE.asString(), major, minor, path);
-                    to = format(Locale.ROOT, "%s%d.%d.0", LT.asString(), major, (minor + 1));
+                    from = format(Locale.ROOT, "%s%d.%d.%d%s", GTE.asString(), major, minor, path, pr);
+                    to = format(Locale.ROOT, "%s%d.%d.0%s", LT.asString(), major, (minor + 1), pr);
                 }
             } else {
-                from = format(Locale.ROOT, "%s%d.%d.%d", GTE.asString(), major, minor, path);
-                to = format(Locale.ROOT, "%s%d.0.0", LT.asString(), (major + 1));
+                from = format(Locale.ROOT, "%s%d.%d.%d%s", GTE.asString(), major, minor, path, pr);
+                to = format(Locale.ROOT, "%s%d.0.0%s", LT.asString(), (major + 1), pr);
             }
         }
 

--- a/src/main/java/org/semver4j/internal/range/processor/CaretProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/CaretProcessor.java
@@ -78,14 +78,14 @@ public class CaretProcessor extends Processor {
         } else {
             if (major == 0) {
                 if (minor == 0) {
-                    from = format(Locale.ROOT, "%s%d.%d.%d%s", GTE.asString(), major, minor, path, pr);
+                    from = format(Locale.ROOT, "%s%d.%d.%d", GTE.asString(), major, minor, path);
                     to = format(Locale.ROOT, "%s%d.%d.%d%s", LT.asString(), major, minor, (path + 1), pr);
                 } else {
-                    from = format(Locale.ROOT, "%s%d.%d.%d%s", GTE.asString(), major, minor, path, pr);
+                    from = format(Locale.ROOT, "%s%d.%d.%d", GTE.asString(), major, minor, path);
                     to = format(Locale.ROOT, "%s%d.%d.0%s", LT.asString(), major, (minor + 1), pr);
                 }
             } else {
-                from = format(Locale.ROOT, "%s%d.%d.%d%s", GTE.asString(), major, minor, path, pr);
+                from = format(Locale.ROOT, "%s%d.%d.%d", GTE.asString(), major, minor, path);
                 to = format(Locale.ROOT, "%s%d.0.0%s", LT.asString(), (major + 1), pr);
             }
         }

--- a/src/main/java/org/semver4j/internal/range/processor/GreaterThanOrEqualZeroProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/GreaterThanOrEqualZeroProcessor.java
@@ -21,10 +21,10 @@ import static org.semver4j.Range.RangeOperator.GTE;
  */
 @NullMarked
 @Deprecated
-public class GreaterThanOrEqualZeroProcessor extends Processor {
+public class GreaterThanOrEqualZeroProcessor implements Processor {
     @Override
     @Nullable
-    public String tryProcess(String range) {
+    public String process(String range, boolean includePrerelease) {
         if (range.equals("latest") || range.equals("latest.integration") || range.equals("*") || range.isEmpty()) {
             return format(Locale.ROOT, "%s%s", GTE.asString(), Semver.ZERO);
         }

--- a/src/main/java/org/semver4j/internal/range/processor/GreaterThanOrEqualZeroProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/GreaterThanOrEqualZeroProcessor.java
@@ -21,7 +21,7 @@ import static org.semver4j.Range.RangeOperator.GTE;
  */
 @NullMarked
 @Deprecated
-public class GreaterThanOrEqualZeroProcessor implements Processor {
+public class GreaterThanOrEqualZeroProcessor extends Processor {
     @Override
     @Nullable
     public String tryProcess(String range) {

--- a/src/main/java/org/semver4j/internal/range/processor/HyphenProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/HyphenProcessor.java
@@ -1,6 +1,5 @@
 package org.semver4j.internal.range.processor;
 
-import com.google.common.base.Strings;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.semver4j.Semver;
@@ -11,9 +10,7 @@ import java.util.regex.Pattern;
 
 import static java.lang.String.format;
 import static java.util.regex.Pattern.compile;
-import static org.semver4j.Range.RangeOperator.GTE;
-import static org.semver4j.Range.RangeOperator.LT;
-import static org.semver4j.Range.RangeOperator.LTE;
+import static org.semver4j.Range.RangeOperator.*;
 import static org.semver4j.internal.Tokenizers.HYPHEN;
 import static org.semver4j.internal.range.processor.RangesUtils.*;
 
@@ -89,7 +86,7 @@ public class HyphenProcessor extends Processor {
             if (patchIsX) {
                 return format(Locale.ROOT, "%s%d.%d.0%s", LT.asString(), toMajor, (toMinor + 1), pr);
             } else {
-                if(!isNotBlank(preRelease)) {
+                if (!isNotBlank(preRelease)) {
                     return format(Locale.ROOT, "%s%d.%d.%d%s", LT.asString(), toMajor, toMinor, (toPatch + 1), pr);
                 } else {
                     return format(Locale.ROOT, "%s%d.%d.%d%s", LTE.asString(), toMajor, toMinor, toPatch, "-" + preRelease);

--- a/src/main/java/org/semver4j/internal/range/processor/HyphenProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/HyphenProcessor.java
@@ -20,10 +20,18 @@ import static org.semver4j.internal.range.processor.RangesUtils.*;
  * <br>
  * Translates:
  * <ul>
- *     <li>{@code 1.2.3 - 2.3.4} to {@code ≥1.2.3 ≤2.3.4}</li>
- *     <li>{@code 1.2 - 2.3.4} to {@code ≥1.2.0 ≤2.3.4}</li>
+ *     <li>{@code 1.2.3 - 2.3.4} to {@code ≥1.2.3 <2.3.5}</li>
+ *     <li>{@code 1.2 - 2.3.4} to {@code ≥1.2.0 <2.3.5}</li>
  *     <li>{@code 1.2.3 - 2.3} to {@code ≥1.2.3 <2.4.0}</li>
  *     <li>{@code 1.2.3 - 2} to {@code ≥1.2.3 <3.0.0}</li>
+ * </ul>
+ *
+ * If the prerelease flag is set to true, will translate:
+ * <ul>
+ *     <li>{@code 1.2.3 - 2.3.4} to {@code ≥1.2.3 <2.3.5-0}</li>
+ *     <li>{@code 1.2 - 2.3.4} to {@code ≥1.2.0 <2.3.5-0}</li>
+ *     <li>{@code 1.2.3 - 2.3} to {@code ≥1.2.3 <2.4.0-0}</li>
+ *     <li>{@code 1.2.3 - 2} to {@code ≥1.2.3 <3.0.0-0}</li>
  * </ul>
  */
 @NullMarked

--- a/src/main/java/org/semver4j/internal/range/processor/HyphenProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/HyphenProcessor.java
@@ -1,7 +1,9 @@
 package org.semver4j.internal.range.processor;
 
+import com.google.common.base.Strings;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+import org.semver4j.Semver;
 
 import java.util.Locale;
 import java.util.regex.Matcher;
@@ -13,8 +15,7 @@ import static org.semver4j.Range.RangeOperator.GTE;
 import static org.semver4j.Range.RangeOperator.LT;
 import static org.semver4j.Range.RangeOperator.LTE;
 import static org.semver4j.internal.Tokenizers.HYPHEN;
-import static org.semver4j.internal.range.processor.RangesUtils.isX;
-import static org.semver4j.internal.range.processor.RangesUtils.parseIntWithXSupport;
+import static org.semver4j.internal.range.processor.RangesUtils.*;
 
 /**
  * <p>Processor for translate <a href="https://github.com/npm/node-semver#hyphen-ranges-xyz---abc">hyphen ranges</a>
@@ -29,7 +30,8 @@ import static org.semver4j.internal.range.processor.RangesUtils.parseIntWithXSup
  * </ul>
  */
 @NullMarked
-public class HyphenProcessor implements Processor {
+//TODO(ading): Add PR flag support
+public class HyphenProcessor extends Processor {
     private static final Pattern pattern = compile(HYPHEN);
 
     @Override
@@ -75,16 +77,23 @@ public class HyphenProcessor implements Processor {
         int toMinor = parseIntWithXSupport(matcher.group(9));
         int toPatch = parseIntWithXSupport(matcher.group(10));
 
+        @Nullable String preRelease = matcher.group(11);
+        String pr = this.getIncludePrerelease() ? Semver.LOWEST_PRERELEASE : "";
+
         boolean minorIsX = isX(toMinor);
         boolean patchIsX = isX(toPatch);
 
         if (minorIsX) {
-            return format(Locale.ROOT, "%s%d.0.0", LT.asString(), (toMajor + 1));
+            return format(Locale.ROOT, "%s%d.0.0%s", LT.asString(), (toMajor + 1), pr);
         } else {
             if (patchIsX) {
-                return format(Locale.ROOT, "%s%d.%d.0", LT.asString(), toMajor, (toMinor + 1));
+                return format(Locale.ROOT, "%s%d.%d.0%s", LT.asString(), toMajor, (toMinor + 1), pr);
             } else {
-                return format(Locale.ROOT, "%s%s", LTE.asString(), to);
+                if(!isNotBlank(preRelease)) {
+                    return format(Locale.ROOT, "%s%d.%d.%d%s", LT.asString(), toMajor, toMinor, (toPatch + 1), pr);
+                } else {
+                    return format(Locale.ROOT, "%s%d.%d.%d%s", LTE.asString(), toMajor, toMinor, toPatch, "-" + preRelease);
+                }
             }
         }
     }

--- a/src/main/java/org/semver4j/internal/range/processor/HyphenProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/HyphenProcessor.java
@@ -29,7 +29,7 @@ import static org.semver4j.internal.range.processor.RangesUtils.*;
  * If the prerelease flag is set to true, will translate:
  * <ul>
  *     <li>{@code 1.2.3 - 2.3.4} to {@code ≥1.2.3 <2.3.5-0}</li>
- *     <li>{@code 1.2 - 2.3.4} to {@code ≥1.2.0 <2.3.5-0}</li>
+ *     <li>{@code 1.2 - 2.3.4} to {@code ≥1.2.0-0 <2.3.5-0}</li>
  *     <li>{@code 1.2.3 - 2.3} to {@code ≥1.2.3 <2.4.0-0}</li>
  *     <li>{@code 1.2.3 - 2} to {@code ≥1.2.3 <3.0.0-0}</li>
  * </ul>
@@ -61,14 +61,16 @@ public class HyphenProcessor extends Processor {
         int fromMinor = parseIntWithXSupport(matcher.group(3));
         int fromPatch = parseIntWithXSupport(matcher.group(4));
 
+        String pr = this.getIncludePrerelease() ? Semver.LOWEST_PRERELEASE : "";
+
         boolean minorIsX = isX(fromMinor);
         boolean patchIsX = isX(fromPatch);
 
         if (minorIsX) {
-            return format(Locale.ROOT, "%s%d.0.0", GTE.asString(), fromMajor);
+            return format(Locale.ROOT, "%s%d.0.0%s", GTE.asString(), fromMajor, pr);
         } else {
             if (patchIsX) {
-                return format(Locale.ROOT, "%s%d.%d.0", GTE.asString(), fromMajor, fromMinor);
+                return format(Locale.ROOT, "%s%d.%d.0%s", GTE.asString(), fromMajor, fromMinor, pr);
             } else {
                 return format(Locale.ROOT, "%s%s", GTE.asString(), from);
             }

--- a/src/main/java/org/semver4j/internal/range/processor/HyphenProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/HyphenProcessor.java
@@ -2,7 +2,6 @@ package org.semver4j.internal.range.processor;
 
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
-import org.semver4j.Semver;
 
 import java.util.Locale;
 import java.util.regex.Matcher;
@@ -25,7 +24,7 @@ import static org.semver4j.internal.range.processor.RangesUtils.*;
  *     <li>{@code 1.2.3 - 2.3} to {@code ≥1.2.3 <2.4.0}</li>
  *     <li>{@code 1.2.3 - 2} to {@code ≥1.2.3 <3.0.0}</li>
  * </ul>
- *
+ * <p>
  * If the prerelease flag is set to true, will translate:
  * <ul>
  *     <li>{@code 1.2.3 - 2.3.4} to {@code ≥1.2.3 <2.3.5-0}</li>

--- a/src/main/java/org/semver4j/internal/range/processor/IvyProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/IvyProcessor.java
@@ -42,7 +42,7 @@ import static org.semver4j.internal.range.processor.RangesUtils.*;
  * </ul>
  */
 @NullMarked
-public class IvyProcessor extends Processor {
+public class IvyProcessor implements Processor {
     private static final String LATEST = "latest";
     private static final String LATEST_INTEGRATION = LATEST + ".integration";
 
@@ -50,9 +50,9 @@ public class IvyProcessor extends Processor {
 
     @Override
     @Nullable
-    public String tryProcess(String range) {
+    public String process(String range, boolean includePrerelease) {
         if (range.equals(LATEST) || range.equals(LATEST_INTEGRATION)) {
-            return this.getIncludePrerelease() ? ALL_RANGE_WITH_PRERELEASE : ALL_RANGE;
+            return includePrerelease ? ALL_RANGE_WITH_PRERELEASE : ALL_RANGE;
         }
 
         Matcher matcher = PATTERN.matcher(range);

--- a/src/main/java/org/semver4j/internal/range/processor/IvyProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/IvyProcessor.java
@@ -14,9 +14,7 @@ import static org.semver4j.Range.RangeOperator.GTE;
 import static org.semver4j.Range.RangeOperator.LT;
 import static org.semver4j.Range.RangeOperator.LTE;
 import static org.semver4j.internal.Tokenizers.IVY;
-import static org.semver4j.internal.range.processor.RangesUtils.ALL_RANGE;
-import static org.semver4j.internal.range.processor.RangesUtils.isX;
-import static org.semver4j.internal.range.processor.RangesUtils.parseIntWithXSupport;
+import static org.semver4j.internal.range.processor.RangesUtils.*;
 
 /**
  * <p>Processor for translate <a href="https://ant.apache.org/ivy/history/latest-milestone/settings/version-matchers.html">Ivy ranges</a>
@@ -38,7 +36,7 @@ import static org.semver4j.internal.range.processor.RangesUtils.parseIntWithXSup
  * </ul>
  */
 @NullMarked
-public class IvyProcessor implements Processor {
+public class IvyProcessor extends Processor {
     private static final String LATEST = "latest";
     private static final String LATEST_INTEGRATION = LATEST + ".integration";
 
@@ -48,7 +46,7 @@ public class IvyProcessor implements Processor {
     @Nullable
     public String tryProcess(String range) {
         if (range.equals(LATEST) || range.equals(LATEST_INTEGRATION)) {
-            return ALL_RANGE;
+            return this.getIncludePrerelease() ? ALL_RANGE_WITH_PRERELEASE : ALL_RANGE;
         }
 
         Matcher matcher = PATTERN.matcher(range);

--- a/src/main/java/org/semver4j/internal/range/processor/IvyProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/IvyProcessor.java
@@ -34,6 +34,12 @@ import static org.semver4j.internal.range.processor.RangesUtils.*;
  *     <li>{@code latest} to {@code ≥0.0.0}</li>
  *     <li>{@code latest.integration} to {@code ≥0.0.0}</li>
  * </ul>
+ *
+ * If the prerelease flag is set to true, translate the same as if the flag is not set, except for the following:
+ * <ul>
+ *     <li>{@code latest} to {@code ≥0.0.0-0}</li>
+ *     <li>{@code latest.integration} to {@code ≥0.0.0-0}</li>
+ * </ul>
  */
 @NullMarked
 public class IvyProcessor extends Processor {

--- a/src/main/java/org/semver4j/internal/range/processor/Processor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/Processor.java
@@ -8,12 +8,25 @@ import org.jspecify.annotations.Nullable;
  * Processor for pipeline range translations.
  */
 @NullMarked
-public interface Processor {
+public abstract class Processor {
+    private boolean includePrerelease = false;
+
     @Deprecated
-    default String process(String range) {
+    public String process(String range) {
         return Optional.ofNullable(tryProcess(range)).orElse(range);
     }
 
     @Nullable
-    String tryProcess(String range);
+    public abstract String tryProcess(String range);
+
+    public Processor includePrerelease() {
+        this.includePrerelease = true;
+        return this;
+    }
+
+    boolean getIncludePrerelease() {
+        return this.includePrerelease;
+    }
+
+
 }

--- a/src/main/java/org/semver4j/internal/range/processor/Processor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/Processor.java
@@ -9,7 +9,7 @@ import org.jspecify.annotations.Nullable;
  */
 @NullMarked
 public abstract class Processor {
-    private boolean includePrerelease = false;
+    private boolean includePrerelease;
 
     @Deprecated
     public String process(String range) {

--- a/src/main/java/org/semver4j/internal/range/processor/Processor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/Processor.java
@@ -1,32 +1,22 @@
 package org.semver4j.internal.range.processor;
 
-import java.util.Optional;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+
+import java.util.Optional;
 
 /**
  * Processor for pipeline range translations.
  */
 @NullMarked
-public abstract class Processor {
-    private boolean includePrerelease;
+public interface Processor {
+    String LOWEST_PRERELEASE = "-0";
 
     @Deprecated
-    public String process(String range) {
-        return Optional.ofNullable(tryProcess(range)).orElse(range);
+    default String process(String range) {
+        return Optional.ofNullable(process(range, false)).orElse(range);
     }
 
     @Nullable
-    public abstract String tryProcess(String range);
-
-    public Processor includePrerelease() {
-        this.includePrerelease = true;
-        return this;
-    }
-
-    boolean getIncludePrerelease() {
-        return this.includePrerelease;
-    }
-
-
+    String process(String range, boolean includePrerelease);
 }

--- a/src/main/java/org/semver4j/internal/range/processor/RangesUtils.java
+++ b/src/main/java/org/semver4j/internal/range/processor/RangesUtils.java
@@ -19,6 +19,9 @@ final class RangesUtils {
     static final String SPACE = " ";
     static final String ALL_RANGE = format(Locale.ROOT, "%s%s", GTE.asString(), Semver.ZERO);
 
+    @NotNull
+    static final String ALL_RANGE_WITH_PRERELEASE = format(Locale.ROOT, "%s%s%s", GTE.asString(), Semver.ZERO, Semver.LOWEST_PRERELEASE);
+
     private static final int X_RANGE_MARKER = -1;
 
     private RangesUtils() {

--- a/src/main/java/org/semver4j/internal/range/processor/RangesUtils.java
+++ b/src/main/java/org/semver4j/internal/range/processor/RangesUtils.java
@@ -18,9 +18,7 @@ final class RangesUtils {
     static final String EMPTY = "";
     static final String SPACE = " ";
     static final String ALL_RANGE = format(Locale.ROOT, "%s%s", GTE.asString(), Semver.ZERO);
-
-    @NotNull
-    static final String ALL_RANGE_WITH_PRERELEASE = format(Locale.ROOT, "%s%s%s", GTE.asString(), Semver.ZERO, Semver.LOWEST_PRERELEASE);
+    static final String ALL_RANGE_WITH_PRERELEASE = format(Locale.ROOT, "%s%s%s", GTE.asString(), Semver.ZERO, Processor.LOWEST_PRERELEASE);
 
     private static final int X_RANGE_MARKER = -1;
 

--- a/src/main/java/org/semver4j/internal/range/processor/TildeProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/TildeProcessor.java
@@ -2,7 +2,6 @@ package org.semver4j.internal.range.processor;
 
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
-import org.semver4j.Semver;
 
 import java.util.Locale;
 import java.util.regex.Matcher;
@@ -13,9 +12,7 @@ import static java.util.regex.Pattern.compile;
 import static org.semver4j.Range.RangeOperator.GTE;
 import static org.semver4j.Range.RangeOperator.LT;
 import static org.semver4j.internal.Tokenizers.TILDE;
-import static org.semver4j.internal.range.processor.RangesUtils.isNotBlank;
-import static org.semver4j.internal.range.processor.RangesUtils.isX;
-import static org.semver4j.internal.range.processor.RangesUtils.parseIntWithXSupport;
+import static org.semver4j.internal.range.processor.RangesUtils.*;
 
 /**
  * <p>Processor for translate <a href="https://github.com/npm/node-semver#tilde-ranges-123-12-1">tilde ranges</a>
@@ -30,7 +27,7 @@ import static org.semver4j.internal.range.processor.RangesUtils.parseIntWithXSup
  *     <li>{@code ~0.2} to {@code ≥0.2.0 <0.3.0}</li>
  *     <li>{@code ~0} to {@code ≥0.0.0 <1.0.0}</li>
  * </ul>
- *
+ * <p>
  * If the prerelease flag is set to true, translates:
  * <ul>
  *     <li>{@code ~1.2.3} to {@code ≥1.2.3 <1.3.0-0}</li>

--- a/src/main/java/org/semver4j/internal/range/processor/TildeProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/TildeProcessor.java
@@ -2,6 +2,7 @@ package org.semver4j.internal.range.processor;
 
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+import org.semver4j.Semver;
 
 import java.util.Locale;
 import java.util.regex.Matcher;
@@ -31,7 +32,7 @@ import static org.semver4j.internal.range.processor.RangesUtils.parseIntWithXSup
  * </ul>
  */
 @NullMarked
-public class TildeProcessor implements Processor {
+public class TildeProcessor extends Processor {
     private static final Pattern pattern = compile(TILDE);
 
     @Override
@@ -50,19 +51,20 @@ public class TildeProcessor implements Processor {
 
         String from;
         String to;
+        String pr = this.getIncludePrerelease() ? Semver.LOWEST_PRERELEASE : "";
 
         if (isX(minor)) {
-            from = format(Locale.ROOT, "%s%d.0.0", GTE.asString(), major);
-            to = format(Locale.ROOT, "%s%d.0.0", LT.asString(), (major + 1));
+            from = format(Locale.ROOT, "%s%d.0.0%s", GTE.asString(), major, pr);
+            to = format(Locale.ROOT, "%s%d.0.0%s", LT.asString(), (major + 1), pr);
         } else if (isX(path)) {
-            from = format(Locale.ROOT, "%s%d.%d.0", GTE.asString(), major, minor);
-            to = format(Locale.ROOT, "%s%d.%d.0", LT.asString(), major, (minor + 1));
+            from = format(Locale.ROOT, "%s%d.%d.0%s", GTE.asString(), major, minor, pr);
+            to = format(Locale.ROOT, "%s%d.%d.0%s", LT.asString(), major, (minor + 1), pr);
         } else if (isNotBlank(preRelease)) {
             from = format(Locale.ROOT, "%s%d.%d.%d-%s", GTE.asString(), major, minor, path, preRelease);
-            to = format(Locale.ROOT, "%s%d.%d.0", LT.asString(), major, (minor + 1));
+            to = format(Locale.ROOT, "%s%d.%d.0%s", LT.asString(), major, (minor + 1), pr);
         } else {
-            from = format(Locale.ROOT, "%s%d.%d.%d", GTE.asString(), major, minor, path);
-            to = format(Locale.ROOT, "%s%d.%d.0", LT.asString(), major, (minor + 1));
+            from = format(Locale.ROOT, "%s%d.%d.%d%s", GTE.asString(), major, minor, path, pr);
+            to = format(Locale.ROOT, "%s%d.%d.0%s", LT.asString(), major, (minor + 1), pr);
         }
 
         return format(Locale.ROOT, "%s %s", from, to);

--- a/src/main/java/org/semver4j/internal/range/processor/TildeProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/TildeProcessor.java
@@ -63,7 +63,7 @@ public class TildeProcessor extends Processor {
             from = format(Locale.ROOT, "%s%d.%d.%d-%s", GTE.asString(), major, minor, path, preRelease);
             to = format(Locale.ROOT, "%s%d.%d.0%s", LT.asString(), major, (minor + 1), pr);
         } else {
-            from = format(Locale.ROOT, "%s%d.%d.%d%s", GTE.asString(), major, minor, path, pr);
+            from = format(Locale.ROOT, "%s%d.%d.%d", GTE.asString(), major, minor, path);
             to = format(Locale.ROOT, "%s%d.%d.0%s", LT.asString(), major, (minor + 1), pr);
         }
 

--- a/src/main/java/org/semver4j/internal/range/processor/TildeProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/TildeProcessor.java
@@ -30,6 +30,16 @@ import static org.semver4j.internal.range.processor.RangesUtils.parseIntWithXSup
  *     <li>{@code ~0.2} to {@code ≥0.2.0 <0.3.0}</li>
  *     <li>{@code ~0} to {@code ≥0.0.0 <1.0.0}</li>
  * </ul>
+ *
+ * If the prerelease flag is set to true, translates:
+ * <ul>
+ *     <li>{@code ~1.2.3} to {@code ≥1.2.3 <1.3.0-0}</li>
+ *     <li>{@code ~1.2} to {@code ≥1.2.0-0 <1.3.0-0}</li>
+ *     <li>{@code ~1} to {@code ≥1.0.0-0 <2.0.0-0}</li>
+ *     <li>{@code ~0.2.3} to {@code ≥0.2.3 <0.3.0-0}</li>
+ *     <li>{@code ~0.2} to {@code ≥0.2.0-0 <0.3.0-0}</li>
+ *     <li>{@code ~0} to {@code ≥0.0.0-0 <1.0.0-0}</li>
+ * </ul>
  */
 @NullMarked
 public class TildeProcessor extends Processor {

--- a/src/main/java/org/semver4j/internal/range/processor/TildeProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/TildeProcessor.java
@@ -42,12 +42,12 @@ import static org.semver4j.internal.range.processor.RangesUtils.parseIntWithXSup
  * </ul>
  */
 @NullMarked
-public class TildeProcessor extends Processor {
+public class TildeProcessor implements Processor {
     private static final Pattern pattern = compile(TILDE);
 
     @Override
     @Nullable
-    public String tryProcess(String range) {
+    public String process(String range, boolean includePrerelease) {
         Matcher matcher = pattern.matcher(range);
 
         if (!matcher.matches()) {
@@ -61,20 +61,20 @@ public class TildeProcessor extends Processor {
 
         String from;
         String to;
-        String pr = this.getIncludePrerelease() ? Semver.LOWEST_PRERELEASE : "";
+        String prerelease = includePrerelease ? Processor.LOWEST_PRERELEASE : "";
 
         if (isX(minor)) {
-            from = format(Locale.ROOT, "%s%d.0.0%s", GTE.asString(), major, pr);
-            to = format(Locale.ROOT, "%s%d.0.0%s", LT.asString(), (major + 1), pr);
+            from = format(Locale.ROOT, "%s%d.0.0%s", GTE.asString(), major, prerelease);
+            to = format(Locale.ROOT, "%s%d.0.0%s", LT.asString(), (major + 1), prerelease);
         } else if (isX(path)) {
-            from = format(Locale.ROOT, "%s%d.%d.0%s", GTE.asString(), major, minor, pr);
-            to = format(Locale.ROOT, "%s%d.%d.0%s", LT.asString(), major, (minor + 1), pr);
+            from = format(Locale.ROOT, "%s%d.%d.0%s", GTE.asString(), major, minor, prerelease);
+            to = format(Locale.ROOT, "%s%d.%d.0%s", LT.asString(), major, (minor + 1), prerelease);
         } else if (isNotBlank(preRelease)) {
             from = format(Locale.ROOT, "%s%d.%d.%d-%s", GTE.asString(), major, minor, path, preRelease);
-            to = format(Locale.ROOT, "%s%d.%d.0%s", LT.asString(), major, (minor + 1), pr);
+            to = format(Locale.ROOT, "%s%d.%d.0%s", LT.asString(), major, (minor + 1), prerelease);
         } else {
             from = format(Locale.ROOT, "%s%d.%d.%d", GTE.asString(), major, minor, path);
-            to = format(Locale.ROOT, "%s%d.%d.0%s", LT.asString(), major, (minor + 1), pr);
+            to = format(Locale.ROOT, "%s%d.%d.0%s", LT.asString(), major, (minor + 1), prerelease);
         }
 
         return format(Locale.ROOT, "%s %s", from, to);

--- a/src/main/java/org/semver4j/internal/range/processor/XRangeProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/XRangeProcessor.java
@@ -30,18 +30,18 @@ import static org.semver4j.internal.range.processor.RangesUtils.parseIntWithXSup
  * <br>
  */
 @NullMarked
-public class XRangeProcessor extends Processor {
+public class XRangeProcessor implements Processor {
     private static final Pattern pattern = compile(XRANGE);
 
     @Override
     @Nullable
-    public String tryProcess(String range) {
+    public String process(String range, boolean includePrerelease) {
         String[] rangeVersions = range.split("\\s+");
 
         List<String> objects = new ArrayList<>();
         for (String rangeVersion : rangeVersions) {
             Matcher matcher = pattern.matcher(rangeVersion);
-            String pr = this.getIncludePrerelease() ? Semver.LOWEST_PRERELEASE : "";
+            String prerelease = includePrerelease ? Processor.LOWEST_PRERELEASE : "";
 
             if (matcher.matches()) {
                 String fullRange = matcher.group(0);
@@ -79,16 +79,16 @@ public class XRangeProcessor extends Processor {
                         minor = 0;
                     }
 
-                    String from = format(Locale.ROOT, "%s%d.%d.%d%s", compareSign, major, minor, patch, pr);
+                    String from = format(Locale.ROOT, "%s%d.%d.%d%s", compareSign, major, minor, patch, prerelease);
                     objects.add(from);
                 } else if (isX(minor)) {
-                    String from = format(Locale.ROOT, "%s%d.0.0%s", GTE.asString(), major, pr);
-                    String to = format(Locale.ROOT, "%s%d.0.0%s", LT.asString(), (major + 1), pr);
+                    String from = format(Locale.ROOT, "%s%d.0.0%s", GTE.asString(), major, prerelease);
+                    String to = format(Locale.ROOT, "%s%d.0.0%s", LT.asString(), (major + 1), prerelease);
                     objects.add(from);
                     objects.add(to);
                 } else if (isX(patch)) {
-                    String from = format(Locale.ROOT, "%s%d.%d.0%s", GTE.asString(), major, minor, pr);
-                    String to = format(Locale.ROOT, "%s%d.%d.0%s", LT.asString(), major, (minor + 1), pr);
+                    String from = format(Locale.ROOT, "%s%d.%d.0%s", GTE.asString(), major, minor, prerelease);
+                    String to = format(Locale.ROOT, "%s%d.%d.0%s", LT.asString(), major, (minor + 1), prerelease);
                     objects.add(from);
                     objects.add(to);
                 } else {

--- a/src/main/java/org/semver4j/internal/range/processor/XRangeProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/XRangeProcessor.java
@@ -2,6 +2,7 @@ package org.semver4j.internal.range.processor;
 
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+import org.semver4j.Semver;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,7 +30,7 @@ import static org.semver4j.internal.range.processor.RangesUtils.parseIntWithXSup
  * <br>
  */
 @NullMarked
-public class XRangeProcessor implements Processor {
+public class XRangeProcessor extends Processor {
     private static final Pattern pattern = compile(XRANGE);
 
     @Override
@@ -40,6 +41,7 @@ public class XRangeProcessor implements Processor {
         List<String> objects = new ArrayList<>();
         for (String rangeVersion : rangeVersions) {
             Matcher matcher = pattern.matcher(rangeVersion);
+            String pr = this.getIncludePrerelease() ? Semver.LOWEST_PRERELEASE : "";
 
             if (matcher.matches()) {
                 String fullRange = matcher.group(0);
@@ -77,16 +79,16 @@ public class XRangeProcessor implements Processor {
                         minor = 0;
                     }
 
-                    String from = format(Locale.ROOT, "%s%d.%d.%d", compareSign, major, minor, patch);
+                    String from = format(Locale.ROOT, "%s%d.%d.%d%s", compareSign, major, minor, patch, pr);
                     objects.add(from);
                 } else if (isX(minor)) {
-                    String from = format(Locale.ROOT, "%s%d.0.0", GTE.asString(), major);
-                    String to = format(Locale.ROOT, "%s%d.0.0", LT.asString(), (major + 1));
+                    String from = format(Locale.ROOT, "%s%d.0.0%s", GTE.asString(), major, pr);
+                    String to = format(Locale.ROOT, "%s%d.0.0%s", LT.asString(), (major + 1), pr);
                     objects.add(from);
                     objects.add(to);
                 } else if (isX(patch)) {
-                    String from = format(Locale.ROOT, "%s%d.%d.0", GTE.asString(), major, minor);
-                    String to = format(Locale.ROOT, "%s%d.%d.0", LT.asString(), major, (minor + 1));
+                    String from = format(Locale.ROOT, "%s%d.%d.0%s", GTE.asString(), major, minor, pr);
+                    String to = format(Locale.ROOT, "%s%d.%d.0%s", LT.asString(), major, (minor + 1), pr);
                     objects.add(from);
                     objects.add(to);
                 } else {

--- a/src/main/java/org/semver4j/internal/range/processor/XRangeProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/XRangeProcessor.java
@@ -2,7 +2,6 @@ package org.semver4j.internal.range.processor;
 
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
-import org.semver4j.Semver;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,16 +12,9 @@ import java.util.regex.Pattern;
 import static java.lang.String.format;
 import static java.lang.String.join;
 import static java.util.regex.Pattern.compile;
-import static org.semver4j.Range.RangeOperator.EQ;
-import static org.semver4j.Range.RangeOperator.GT;
-import static org.semver4j.Range.RangeOperator.GTE;
-import static org.semver4j.Range.RangeOperator.LT;
-import static org.semver4j.Range.RangeOperator.LTE;
+import static org.semver4j.Range.RangeOperator.*;
 import static org.semver4j.internal.Tokenizers.XRANGE;
-import static org.semver4j.internal.range.processor.RangesUtils.EMPTY;
-import static org.semver4j.internal.range.processor.RangesUtils.SPACE;
-import static org.semver4j.internal.range.processor.RangesUtils.isX;
-import static org.semver4j.internal.range.processor.RangesUtils.parseIntWithXSupport;
+import static org.semver4j.internal.range.processor.RangesUtils.*;
 
 /**
  * <p>Processor for translate <a href="https://github.com/npm/node-semver#x-ranges-12x-1x-12-">X-Ranges</a> into classic

--- a/src/test/java/org/semver4j/SemverTest.java
+++ b/src/test/java/org/semver4j/SemverTest.java
@@ -898,7 +898,6 @@ class SemverTest {
         assertThat(lowerThan1).isEqualTo(lowerThan2);
     }
 
-
     @ParameterizedTest
     @MethodSource({"getParametersNoIncludePrerelease", "getParametersCommon"})
     void shouldCheckSatisfiesNoIncludePrerelease(String version, String range, boolean expected) {
@@ -906,7 +905,7 @@ class SemverTest {
         Semver semver = new Semver(version);
 
         //when
-        boolean satisfies = semver.satisfies(range, false);
+        boolean satisfies = semver.satisfies(range);
 
         //then
         assertThat(satisfies).isEqualTo(expected);

--- a/src/test/java/org/semver4j/SemverTest.java
+++ b/src/test/java/org/semver4j/SemverTest.java
@@ -989,7 +989,7 @@ class SemverTest {
 
                     // Tilde ranges
                     arguments("1.2.4-beta", "~1.2.3", true),
-                    arguments("1.2.3-beta", "~1.2.3", true),
+                    arguments("1.2.3-beta", "~1.2.3", false),
                     arguments("1.2.4-beta+exp.sha.5114f85", "~1.2.3", true),
                     arguments("1.2.7-beta", "~1.2", true),
                     arguments("1.2.3-beta", "~1.2", true),
@@ -999,8 +999,8 @@ class SemverTest {
                     // Caret ranges
                     arguments("1.5.4-beta", "^1.2.3", true),
                     arguments("0.2.4-beta", "^0.2.3", true),
-                    arguments("0.0.3-beta", "^0.0.3", true),
-                    arguments("0.0.0-beta", "^0.0.0", true),
+                    arguments("0.0.3-beta", "^0.0.3", false),
+                    arguments("0.0.0-beta", "^0.0.0", false),
 
                     // Comparators
                     arguments("3.3.1-alpha", ">=2.4.x", true),

--- a/src/test/java/org/semver4j/SemverTest.java
+++ b/src/test/java/org/semver4j/SemverTest.java
@@ -898,20 +898,124 @@ class SemverTest {
         assertThat(lowerThan1).isEqualTo(lowerThan2);
     }
 
+
     @ParameterizedTest
-    @MethodSource("getParameters")
-    void shouldCheckSatisfies(String version, String range, boolean expected) {
+    @MethodSource({"getParametersNoIncludePrerelease", "getParametersCommon"})
+    void shouldCheckSatisfiesNoIncludePrerelease(String version, String range, boolean expected) {
         //given
         Semver semver = new Semver(version);
 
         //when
-        boolean satisfies = semver.satisfies(range);
+        boolean satisfies = semver.satisfies(range, false);
 
         //then
         assertThat(satisfies).isEqualTo(expected);
     }
 
-    static Stream<Arguments> getParameters() {
+    @ParameterizedTest
+    @MethodSource({"getParametersIncludePrerelease", "getParametersCommon"})
+    void shouldCheckSatisfiesIncludePrerelease(String version, String range, boolean expected) {
+        //given
+        Semver semver = new Semver(version);
+
+        //when
+        boolean satisfies = semver.satisfies(range, true);
+
+        //then
+        assertThat(satisfies).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> getParametersNoIncludePrerelease() {
+        return Stream.of(
+                // Minor versions:
+                arguments("1.0.0-beta", "1.0", false),
+
+                // Major versions:
+                arguments("1.0.0-beta", "1", false),
+
+                // Hyphen ranges:
+                arguments("1.2.4-beta+exp.sha.5114f85", "1.2.3 - 2.3.4", false),
+                arguments("1.2.4-beta+exp.sha.5114f85", "1.2.3-beta - 2.3.4", false),
+
+                // Wildcard ranges:
+                arguments("1.0.0-beta", "*", false),
+                arguments("3.1.5-beta", "3.1.x", false),
+                arguments("3.1.5-beta+exp.sha.5114f85", "3.1.x", false),
+
+                // Tilde ranges
+                arguments("1.2.4-beta", "~1.2.3", false),
+                arguments("1.2.3-beta", "~1.2.3", false),
+                arguments("1.2.4-beta+exp.sha.5114f85", "~1.2.3", false),
+                arguments("1.2.7-beta", "~1.2", false),
+                arguments("1.2.3-beta", "~1.2", false),
+                arguments("1.2.7-beta", "~1", false),
+                arguments("1.2.3-beta", "~1", false),
+
+                // Caret ranges
+                arguments("1.5.4-beta", "^1.2.3", false),
+                arguments("0.2.4-beta", "^0.2.3", false),
+                arguments("0.0.3-beta", "^0.0.3", false),
+                arguments("0.0.0-beta", "^0.0.0", false),
+
+                // Comparators
+                arguments("3.3.1-alpha", ">=2.4.x", false),
+                arguments("3.3.1-alpha", ">=3.3.x", false),
+                arguments("3.0.0-alpha", "<3.0.0", false),
+
+                // AND ranges
+                arguments("2.0.1-alpha", ">2.0.0 <3.0.0", false),
+
+                //Complex ranges
+                arguments("2.3.4-alpha", "1.x || ^2", false)
+        );
+    }
+
+    static Stream<Arguments> getParametersIncludePrerelease() {
+            return Stream.of(
+                    // Minor versions:
+                    arguments("1.0.0-beta", "1.0", true),
+
+                    // Major versions:
+                    arguments("1.0.0-beta", "1", true),
+
+                    // Hyphen ranges:
+                    arguments("1.2.4-beta+exp.sha.5114f85", "1.2.3 - 2.3.4", true),
+                    arguments("1.2.4-beta+exp.sha.5114f85", "1.2.3-beta - 2.3.4", true),
+
+                    // Wildcard ranges:
+                    arguments("1.0.0-beta", "*", true),
+                    arguments("3.1.5-beta", "3.1.x", true),
+                    arguments("3.1.5-beta+exp.sha.5114f85", "3.1.x", true),
+
+                    // Tilde ranges
+                    arguments("1.2.4-beta", "~1.2.3", true),
+                    arguments("1.2.3-beta", "~1.2.3", true),
+                    arguments("1.2.4-beta+exp.sha.5114f85", "~1.2.3", true),
+                    arguments("1.2.7-beta", "~1.2", true),
+                    arguments("1.2.3-beta", "~1.2", true),
+                    arguments("1.2.7-beta", "~1", true),
+                    arguments("1.2.3-beta", "~1", true),
+
+                    // Caret ranges
+                    arguments("1.5.4-beta", "^1.2.3", true),
+                    arguments("0.2.4-beta", "^0.2.3", true),
+                    arguments("0.0.3-beta", "^0.0.3", true),
+                    arguments("0.0.0-beta", "^0.0.0", true),
+
+                    // Comparators
+                    arguments("3.3.1-alpha", ">=2.4.x", true),
+                    arguments("3.3.1-alpha", ">=3.3.x", true),
+                    arguments("3.0.0-alpha", "<3.0.0", true),
+
+                    // AND ranges
+                    arguments("2.0.1-alpha", ">2.0.0 <3.0.0", true),
+
+                    //Complex ranges
+                    arguments("2.3.4-alpha", "1.x || ^2", true)
+            );
+    }
+
+    static Stream<Arguments> getParametersCommon() {
         return Stream.of(
                 // Fully-qualified versions:
                 arguments("1.0.0", "1.0.0", true),
@@ -929,11 +1033,9 @@ class SemverTest {
                 arguments("1.2.4", "2", false),
 
                 // Hyphen ranges:
-                arguments("1.2.4-beta+exp.sha.5114f85", "1.2.3 - 2.3.4", false),
                 arguments("1.2.4", "1.2.3 - 2.3.4", true),
                 arguments("1.2.3", "1.2.3 - 2.3.4", true),
                 arguments("2.3.4", "1.2.3 - 2.3.4", true),
-                arguments("2.3.0-alpha", "1.2.3 - 2.3.0-beta", true),
                 arguments("2.3.4", "1.2.3 - 2.3", true),
                 arguments("2.3.4", "1.2.3 - 2", true),
                 arguments("4.4.0", "3.X - 4.X", true),
@@ -947,9 +1049,6 @@ class SemverTest {
                 arguments("3.1.5", "", true),
                 arguments("3.1.5", "*", true),
                 arguments("0.0.0", "*", true),
-                arguments("1.0.0-beta", "*", false),
-                arguments("3.1.5-beta", "3.1.x", false),
-                arguments("3.1.5-beta+exp.sha.5114f85", "3.1.x", false),
                 arguments("3.1.5+exp.sha.5114f85", "3.1.x", true),
                 arguments("3.1.5", "3.1.x", true),
                 arguments("3.1.5", "3.1.X", true),
@@ -967,8 +1066,6 @@ class SemverTest {
                 arguments("2.0.0", "3", false),
 
                 // Tilde ranges:
-                arguments("1.2.4-beta", "~1.2.3", false),
-                arguments("1.2.4-beta+exp.sha.5114f85", "~1.2.3", false),
                 arguments("1.2.3", "~1.2.3", true),
                 arguments("1.2.7", "~1.2.3", true),
                 arguments("1.2.2", "~1.2", true),
@@ -1053,7 +1150,6 @@ class SemverTest {
                 arguments("1.9.9", ">=2.0.0", false),
                 arguments("1.9.9", ">=2.0", false),
                 arguments("1.9.9", ">=2", false),
-                arguments("3.3.1-alpha", ">=2.4.x", false),
 
                 arguments("3.3.1", ">=2.4.x", true),
                 arguments("1.9.9", "<=2.0.0", true),
@@ -1070,6 +1166,8 @@ class SemverTest {
                 arguments("3.0.0", "<=2.0.0", false),
                 arguments("3.0.0", "<=2.0", false),
                 arguments("3.0.0", "<=2", false),
+
+                arguments("3.0.0-alpha", ">3.0.0", false),
 
                 // AND ranges:
                 arguments("2.0.1", ">2.0.0 <3.0.0", true),
@@ -1180,8 +1278,7 @@ class SemverTest {
                 arguments("1.3.0", "1.+", true),
                 arguments("1.2.90", "1.+", true),
 
-                arguments("0.0.0", "latest.integration", true)
-        );
+                arguments("0.0.0", "latest.integration", true));
     }
 
     @Test

--- a/src/test/java/org/semver4j/internal/range/RangeProcessorPipelineTest.java
+++ b/src/test/java/org/semver4j/internal/range/RangeProcessorPipelineTest.java
@@ -1,7 +1,6 @@
 package org.semver4j.internal.range;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.semver4j.internal.range.processor.Processor;
 
@@ -15,7 +14,7 @@ class RangeProcessorPipelineTest {
         RangeProcessorPipeline pipeline = RangeProcessorPipeline.startWith(new DummyProcessor(range -> range + "_A"))
                 .addProcessor(new DummyProcessor(range -> range + "_B"))
                 .addProcessor(new DummyProcessor(range -> range + "_C"));
-        assertThat(pipeline.process("RANGE")).isEqualTo("RANGE_A");
+        assertThat(pipeline.process("RANGE", false)).isEqualTo("RANGE_A");
     }
 
     @Test
@@ -23,17 +22,19 @@ class RangeProcessorPipelineTest {
         RangeProcessorPipeline pipeline = RangeProcessorPipeline.startWith(new DummyProcessor(range -> null))
                 .addProcessor(new DummyProcessor(range -> null))
                 .addProcessor(new DummyProcessor(range -> null));
-        assertThat(pipeline.process("RANGE")).isEqualTo("RANGE");
+        assertThat(pipeline.process("RANGE", true)).isEqualTo("RANGE");
     }
 
-    private final class DummyProcessor extends Processor {
+    private static class DummyProcessor implements Processor {
         private final Function<String, String> process;
+
         private DummyProcessor(Function<String, String> process) {
             this.process = process;
         }
 
         @Override
-        public @Nullable String tryProcess(@NotNull String range) {
+        @Nullable
+        public String process(String range) {
             return process.apply(range);
         }
     }

--- a/src/test/java/org/semver4j/internal/range/RangeProcessorPipelineTest.java
+++ b/src/test/java/org/semver4j/internal/range/RangeProcessorPipelineTest.java
@@ -1,6 +1,5 @@
 package org.semver4j.internal.range;
 
-import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.semver4j.internal.range.processor.Processor;
 

--- a/src/test/java/org/semver4j/internal/range/RangeProcessorPipelineTest.java
+++ b/src/test/java/org/semver4j/internal/range/RangeProcessorPipelineTest.java
@@ -1,6 +1,5 @@
 package org.semver4j.internal.range;
 
-import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.semver4j.internal.range.processor.Processor;
 
@@ -33,7 +32,6 @@ class RangeProcessorPipelineTest {
         }
 
         @Override
-        @Nullable
         public String process(String range, boolean includePrerelease) {
             return process.apply(range);
         }

--- a/src/test/java/org/semver4j/internal/range/RangeProcessorPipelineTest.java
+++ b/src/test/java/org/semver4j/internal/range/RangeProcessorPipelineTest.java
@@ -25,7 +25,7 @@ class RangeProcessorPipelineTest {
         assertThat(pipeline.process("RANGE", true)).isEqualTo("RANGE");
     }
 
-    private static class DummyProcessor implements Processor {
+    private final class DummyProcessor implements Processor {
         private final Function<String, String> process;
 
         private DummyProcessor(Function<String, String> process) {

--- a/src/test/java/org/semver4j/internal/range/RangeProcessorPipelineTest.java
+++ b/src/test/java/org/semver4j/internal/range/RangeProcessorPipelineTest.java
@@ -1,5 +1,6 @@
 package org.semver4j.internal.range;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.semver4j.internal.range.processor.Processor;
 

--- a/src/test/java/org/semver4j/internal/range/RangeProcessorPipelineTest.java
+++ b/src/test/java/org/semver4j/internal/range/RangeProcessorPipelineTest.java
@@ -34,7 +34,7 @@ class RangeProcessorPipelineTest {
 
         @Override
         @Nullable
-        public String process(String range) {
+        public String process(String range, boolean includePrerelease) {
             return process.apply(range);
         }
     }

--- a/src/test/java/org/semver4j/internal/range/RangeProcessorPipelineTest.java
+++ b/src/test/java/org/semver4j/internal/range/RangeProcessorPipelineTest.java
@@ -13,7 +13,7 @@ class RangeProcessorPipelineTest {
         RangeProcessorPipeline pipeline = RangeProcessorPipeline.startWith(new DummyProcessor(range -> range + "_A"))
                 .addProcessor(new DummyProcessor(range -> range + "_B"))
                 .addProcessor(new DummyProcessor(range -> range + "_C"));
-        assertThat(pipeline.process("RANGE", false)).isEqualTo("RANGE_A");
+        assertThat(pipeline.process("RANGE")).isEqualTo("RANGE_A");
     }
 
     @Test
@@ -21,7 +21,7 @@ class RangeProcessorPipelineTest {
         RangeProcessorPipeline pipeline = RangeProcessorPipeline.startWith(new DummyProcessor(range -> null))
                 .addProcessor(new DummyProcessor(range -> null))
                 .addProcessor(new DummyProcessor(range -> null));
-        assertThat(pipeline.process("RANGE", true)).isEqualTo("RANGE");
+        assertThat(pipeline.process("RANGE")).isEqualTo("RANGE");
     }
 
     private final class DummyProcessor implements Processor {

--- a/src/test/java/org/semver4j/internal/range/RangeProcessorPipelineTest.java
+++ b/src/test/java/org/semver4j/internal/range/RangeProcessorPipelineTest.java
@@ -5,19 +5,19 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class RangeProcessorPipelineTest {
-    @Test
-    void shouldBeAbleToBuildAPipeline() {
-        RangeProcessorPipeline pipeline = RangeProcessorPipeline.startWith(range -> range + "_A")
-                .addProcessor(range -> range + "_B")
-                .addProcessor(range -> range + "_C");
-        assertThat(pipeline.process("RANGE")).isEqualTo("RANGE_A");
-    }
-
-    @Test
-    void shouldReturnPassedInStringIfNoProcessorIsSuccessful() {
-        RangeProcessorPipeline pipeline = RangeProcessorPipeline.startWith(range -> null)
-                .addProcessor(range -> null)
-                .addProcessor(range -> null);
-        assertThat(pipeline.process("RANGE")).isEqualTo("RANGE");
-    }
+//    @Test
+//    void shouldBeAbleToBuildAPipeline() {
+//        RangeProcessorPipeline pipeline = RangeProcessorPipeline.startWith(range -> range + "_A")
+//                .addProcessor(range -> range + "_B")
+//                .addProcessor(range -> range + "_C");
+//        assertThat(pipeline.process("RANGE")).isEqualTo("RANGE_A");
+//    }
+//
+//    @Test
+//    void shouldReturnPassedInStringIfNoProcessorIsSuccessful() {
+//        RangeProcessorPipeline pipeline = RangeProcessorPipeline.startWith(range -> null)
+//                .addProcessor(range -> null)
+//                .addProcessor(range -> null);
+//        assertThat(pipeline.process("RANGE")).isEqualTo("RANGE");
+//    }
 }

--- a/src/test/java/org/semver4j/internal/range/RangeProcessorPipelineTest.java
+++ b/src/test/java/org/semver4j/internal/range/RangeProcessorPipelineTest.java
@@ -1,23 +1,40 @@
 package org.semver4j.internal.range;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
+import org.semver4j.internal.range.processor.Processor;
+
+import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class RangeProcessorPipelineTest {
-//    @Test
-//    void shouldBeAbleToBuildAPipeline() {
-//        RangeProcessorPipeline pipeline = RangeProcessorPipeline.startWith(range -> range + "_A")
-//                .addProcessor(range -> range + "_B")
-//                .addProcessor(range -> range + "_C");
-//        assertThat(pipeline.process("RANGE")).isEqualTo("RANGE_A");
-//    }
-//
-//    @Test
-//    void shouldReturnPassedInStringIfNoProcessorIsSuccessful() {
-//        RangeProcessorPipeline pipeline = RangeProcessorPipeline.startWith(range -> null)
-//                .addProcessor(range -> null)
-//                .addProcessor(range -> null);
-//        assertThat(pipeline.process("RANGE")).isEqualTo("RANGE");
-//    }
+    @Test
+    void shouldBeAbleToBuildAPipeline() {
+        RangeProcessorPipeline pipeline = RangeProcessorPipeline.startWith(new DummyProcessor(range -> range + "_A"))
+                .addProcessor(new DummyProcessor(range -> range + "_B"))
+                .addProcessor(new DummyProcessor(range -> range + "_C"));
+        assertThat(pipeline.process("RANGE")).isEqualTo("RANGE_A");
+    }
+
+    @Test
+    void shouldReturnPassedInStringIfNoProcessorIsSuccessful() {
+        RangeProcessorPipeline pipeline = RangeProcessorPipeline.startWith(new DummyProcessor(range -> null))
+                .addProcessor(new DummyProcessor(range -> null))
+                .addProcessor(new DummyProcessor(range -> null));
+        assertThat(pipeline.process("RANGE")).isEqualTo("RANGE");
+    }
+
+    private final class DummyProcessor extends Processor {
+        private final Function<String, String> process;
+        private DummyProcessor(Function<String, String> process) {
+            this.process = process;
+        }
+
+        @Override
+        public @Nullable String tryProcess(@NotNull String range) {
+            return process.apply(range);
+        }
+    }
 }

--- a/src/test/java/org/semver4j/internal/range/RangeProcessorPipelineTest.java
+++ b/src/test/java/org/semver4j/internal/range/RangeProcessorPipelineTest.java
@@ -13,7 +13,7 @@ class RangeProcessorPipelineTest {
         RangeProcessorPipeline pipeline = RangeProcessorPipeline.startWith(new DummyProcessor(range -> range + "_A"))
                 .addProcessor(new DummyProcessor(range -> range + "_B"))
                 .addProcessor(new DummyProcessor(range -> range + "_C"));
-        assertThat(pipeline.process("RANGE")).isEqualTo("RANGE_A");
+        assertThat(pipeline.process("RANGE", false)).isEqualTo("RANGE_A");
     }
 
     @Test
@@ -21,7 +21,7 @@ class RangeProcessorPipelineTest {
         RangeProcessorPipeline pipeline = RangeProcessorPipeline.startWith(new DummyProcessor(range -> null))
                 .addProcessor(new DummyProcessor(range -> null))
                 .addProcessor(new DummyProcessor(range -> null));
-        assertThat(pipeline.process("RANGE")).isEqualTo("RANGE");
+        assertThat(pipeline.process("RANGE", false)).isEqualTo("RANGE");
     }
 
     private final class DummyProcessor implements Processor {

--- a/src/test/java/org/semver4j/internal/range/processor/AllVersionsProcessorTest.java
+++ b/src/test/java/org/semver4j/internal/range/processor/AllVersionsProcessorTest.java
@@ -25,4 +25,18 @@ class AllVersionsProcessorTest {
                 arguments("INVALID", null)
         );
     }
+
+    @ParameterizedTest
+    @MethodSource
+    void shouldParseAllVersionsIncludePrerelease(String range, String expectedString) {
+        assertThat(allVersionsProcessor.includePrerelease().tryProcess(range)).isEqualTo(expectedString);
+    }
+
+    static Stream<Arguments> shouldParseAllVersionsIncludePrerelease() {
+        return Stream.of(
+                arguments("*", ">=0.0.0-0"),
+                arguments("", ">=0.0.0-0"),
+                arguments("INVALID", null)
+        );
+    }
 }

--- a/src/test/java/org/semver4j/internal/range/processor/AllVersionsProcessorTest.java
+++ b/src/test/java/org/semver4j/internal/range/processor/AllVersionsProcessorTest.java
@@ -15,7 +15,7 @@ class AllVersionsProcessorTest {
     @ParameterizedTest
     @MethodSource
     void shouldParseAllVersions(String range, String expectedString) {
-        assertThat(allVersionsProcessor.tryProcess(range)).isEqualTo(expectedString);
+        assertThat(allVersionsProcessor.process(range, false)).isEqualTo(expectedString);
     }
 
     static Stream<Arguments> shouldParseAllVersions() {
@@ -29,7 +29,7 @@ class AllVersionsProcessorTest {
     @ParameterizedTest
     @MethodSource
     void shouldParseAllVersionsIncludePrerelease(String range, String expectedString) {
-        assertThat(allVersionsProcessor.includePrerelease().tryProcess(range)).isEqualTo(expectedString);
+        assertThat(allVersionsProcessor.process(range, true)).isEqualTo(expectedString);
     }
 
     static Stream<Arguments> shouldParseAllVersionsIncludePrerelease() {

--- a/src/test/java/org/semver4j/internal/range/processor/CaretProcessorTest.java
+++ b/src/test/java/org/semver4j/internal/range/processor/CaretProcessorTest.java
@@ -30,4 +30,23 @@ class CaretProcessorTest {
                 arguments("INVALID", null)
         );
     }
+
+    @ParameterizedTest
+    @MethodSource
+    void shouldParseCaretRangeIncludePrerelease(String range, String expectedString) {
+        assertThat(processor.includePrerelease().tryProcess(range)).isEqualTo(expectedString);
+    }
+
+    static Stream<Arguments> shouldParseCaretRangeIncludePrerelease() {
+        return Stream.of(
+                arguments("^1", ">=1.0.0-0 <2.0.0-0"),
+                arguments("^1.1", ">=1.1.0-0 <2.0.0-0"),
+                arguments("^1.1.1", ">=1.1.1-0 <2.0.0-0"),
+                arguments("^0.1", ">=0.1.0-0 <0.2.0-0"),
+                arguments("^0.0.1", ">=0.0.1-0 <0.0.2-0"),
+                arguments("^1.0.0-alpha.1", ">=1.0.0-alpha.1 <2.0.0-0"),
+                arguments("^0.1.1-alpha.1", ">=0.1.1-alpha.1 <0.2.0-0"),
+                arguments("INVALID", null)
+        );
+    }
 }

--- a/src/test/java/org/semver4j/internal/range/processor/CaretProcessorTest.java
+++ b/src/test/java/org/semver4j/internal/range/processor/CaretProcessorTest.java
@@ -41,9 +41,9 @@ class CaretProcessorTest {
         return Stream.of(
                 arguments("^1", ">=1.0.0-0 <2.0.0-0"),
                 arguments("^1.1", ">=1.1.0-0 <2.0.0-0"),
-                arguments("^1.1.1", ">=1.1.1-0 <2.0.0-0"),
+                arguments("^1.1.1", ">=1.1.1 <2.0.0-0"),
                 arguments("^0.1", ">=0.1.0-0 <0.2.0-0"),
-                arguments("^0.0.1", ">=0.0.1-0 <0.0.2-0"),
+                arguments("^0.0.1", ">=0.0.1 <0.0.2-0"),
                 arguments("^1.0.0-alpha.1", ">=1.0.0-alpha.1 <2.0.0-0"),
                 arguments("^0.1.1-alpha.1", ">=0.1.1-alpha.1 <0.2.0-0"),
                 arguments("INVALID", null)

--- a/src/test/java/org/semver4j/internal/range/processor/CaretProcessorTest.java
+++ b/src/test/java/org/semver4j/internal/range/processor/CaretProcessorTest.java
@@ -15,7 +15,7 @@ class CaretProcessorTest {
     @ParameterizedTest
     @MethodSource
     void shouldParseCaretRange(String range, String expectedString) {
-        assertThat(processor.tryProcess(range)).isEqualTo(expectedString);
+        assertThat(processor.process(range, false)).isEqualTo(expectedString);
     }
 
     static Stream<Arguments> shouldParseCaretRange() {
@@ -34,7 +34,7 @@ class CaretProcessorTest {
     @ParameterizedTest
     @MethodSource
     void shouldParseCaretRangeIncludePrerelease(String range, String expectedString) {
-        assertThat(processor.includePrerelease().tryProcess(range)).isEqualTo(expectedString);
+        assertThat(processor.process(range, true)).isEqualTo(expectedString);
     }
 
     static Stream<Arguments> shouldParseCaretRangeIncludePrerelease() {

--- a/src/test/java/org/semver4j/internal/range/processor/GreaterThanOrEqualZeroProcessorTest.java
+++ b/src/test/java/org/semver4j/internal/range/processor/GreaterThanOrEqualZeroProcessorTest.java
@@ -16,7 +16,7 @@ class GreaterThanOrEqualZeroProcessorTest {
     @ParameterizedTest
     @MethodSource
     void shouldParseRanges(String range, String expectedString) {
-        assertThat(processor.tryProcess(range)).isEqualTo(expectedString);
+        assertThat(processor.process(range, false)).isEqualTo(expectedString);
     }
 
     static Stream<Arguments> shouldParseRanges() {

--- a/src/test/java/org/semver4j/internal/range/processor/HyphenProcessorTest.java
+++ b/src/test/java/org/semver4j/internal/range/processor/HyphenProcessorTest.java
@@ -25,6 +25,29 @@ class HyphenProcessorTest {
                 arguments("1 - 2.3.4", ">=1.0.0 <=2.3.4"),
                 arguments("1.2.3 - 2.3", ">=1.2.3 <2.4.0"),
                 arguments("1.2.3 - 2", ">=1.2.3 <3.0.0"),
+                arguments("1.2.3-alpha - 2.1.4-beta", ">=1.2.3-alpha <2.1.4-beta"),
+                arguments("1.2 - 2.1.4-beta", ">=1.2.0 <2.1.4-beta"),
+                arguments("1.2.3-alpha - 2.1.4", ">=1.2.3-alpha <2.1.4"),
+                arguments("INVALID", null)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void shouldParseHyphenRangeIncludePrerelease(String range, String expectedString) {
+        assertThat(hyphenProcessor.tryProcess(range)).isEqualTo(expectedString);
+    }
+
+    static Stream<Arguments> shouldParseHyphenRangeIncludePrerelease() {
+        return Stream.of(
+                arguments("1.2.3 - 2.3.4", ">=1.2.3 <=2.3.4-0"),
+                arguments("1.2 - 2.3.4", ">=1.2.0 <=2.3.4-0"),
+                arguments("1 - 2.3.4", ">=1.0.0 <=2.3.4-0"),
+                arguments("1.2.3 - 2.3", ">=1.2.3 <2.4.0-0"),
+                arguments("1.2.3 - 2", ">=1.2.3 <3.0.0-0"),
+                arguments("1.2.3-alpha - 2.1.4-beta", ">=1.2.3-alpha <2.1.4-beta"),
+                arguments("1.2 - 2.1.4-beta", ">=1.2.0 <2.1.4-beta"),
+                arguments("1.2.3-alpha - 2.1.4", ">=1.2.3-alpha <2.1.4-0"),
                 arguments("INVALID", null)
         );
     }

--- a/src/test/java/org/semver4j/internal/range/processor/HyphenProcessorTest.java
+++ b/src/test/java/org/semver4j/internal/range/processor/HyphenProcessorTest.java
@@ -41,12 +41,12 @@ class HyphenProcessorTest {
     static Stream<Arguments> shouldParseHyphenRangeIncludePrerelease() {
         return Stream.of(
                 arguments("1.2.3 - 2.3.4", ">=1.2.3 <2.3.5-0"),
-                arguments("1.2 - 2.3.4", ">=1.2.0 <2.3.5-0"),
-                arguments("1 - 2.3.4", ">=1.0.0 <2.3.5-0"),
+                arguments("1.2 - 2.3.4", ">=1.2.0-0 <2.3.5-0"),
+                arguments("1 - 2.3.4", ">=1.0.0-0 <2.3.5-0"),
                 arguments("1.2.3 - 2.3", ">=1.2.3 <2.4.0-0"),
                 arguments("1.2.3 - 2", ">=1.2.3 <3.0.0-0"),
                 arguments("1.2.3-alpha - 2.1.4-beta", ">=1.2.3-alpha <=2.1.4-beta"),
-                arguments("1.2 - 2.1.4-beta", ">=1.2.0 <=2.1.4-beta"),
+                arguments("1.2 - 2.1.4-beta", ">=1.2.0-0 <=2.1.4-beta"),
                 arguments("1.2.3-alpha - 2.1.4", ">=1.2.3-alpha <2.1.5-0"),
                 arguments("INVALID", null)
         );

--- a/src/test/java/org/semver4j/internal/range/processor/HyphenProcessorTest.java
+++ b/src/test/java/org/semver4j/internal/range/processor/HyphenProcessorTest.java
@@ -15,7 +15,7 @@ class HyphenProcessorTest {
     @ParameterizedTest
     @MethodSource
     void shouldParseHyphenRange(String range, String expectedString) {
-        assertThat(hyphenProcessor.tryProcess(range)).isEqualTo(expectedString);
+        assertThat(hyphenProcessor.process(range, false)).isEqualTo(expectedString);
     }
 
     static Stream<Arguments> shouldParseHyphenRange() {
@@ -35,7 +35,7 @@ class HyphenProcessorTest {
     @ParameterizedTest
     @MethodSource
     void shouldParseHyphenRangeIncludePrerelease(String range, String expectedString) {
-        assertThat(hyphenProcessor.includePrerelease().tryProcess(range)).isEqualTo(expectedString);
+        assertThat(hyphenProcessor.process(range, true)).isEqualTo(expectedString);
     }
 
     static Stream<Arguments> shouldParseHyphenRangeIncludePrerelease() {

--- a/src/test/java/org/semver4j/internal/range/processor/HyphenProcessorTest.java
+++ b/src/test/java/org/semver4j/internal/range/processor/HyphenProcessorTest.java
@@ -20,14 +20,14 @@ class HyphenProcessorTest {
 
     static Stream<Arguments> shouldParseHyphenRange() {
         return Stream.of(
-                arguments("1.2.3 - 2.3.4", ">=1.2.3 <=2.3.4"),
-                arguments("1.2 - 2.3.4", ">=1.2.0 <=2.3.4"),
-                arguments("1 - 2.3.4", ">=1.0.0 <=2.3.4"),
+                arguments("1.2.3 - 2.3.4", ">=1.2.3 <2.3.5"),
+                arguments("1.2 - 2.3.4", ">=1.2.0 <2.3.5"),
+                arguments("1 - 2.3.4", ">=1.0.0 <2.3.5"),
                 arguments("1.2.3 - 2.3", ">=1.2.3 <2.4.0"),
                 arguments("1.2.3 - 2", ">=1.2.3 <3.0.0"),
-                arguments("1.2.3-alpha - 2.1.4-beta", ">=1.2.3-alpha <2.1.4-beta"),
-                arguments("1.2 - 2.1.4-beta", ">=1.2.0 <2.1.4-beta"),
-                arguments("1.2.3-alpha - 2.1.4", ">=1.2.3-alpha <2.1.4"),
+                arguments("1.2.3-alpha - 2.1.4-beta", ">=1.2.3-alpha <=2.1.4-beta"),
+                arguments("1.2 - 2.1.4-beta", ">=1.2.0 <=2.1.4-beta"),
+                arguments("1.2.3-alpha - 2.1.4", ">=1.2.3-alpha <2.1.5"),
                 arguments("INVALID", null)
         );
     }
@@ -35,19 +35,19 @@ class HyphenProcessorTest {
     @ParameterizedTest
     @MethodSource
     void shouldParseHyphenRangeIncludePrerelease(String range, String expectedString) {
-        assertThat(hyphenProcessor.tryProcess(range)).isEqualTo(expectedString);
+        assertThat(hyphenProcessor.includePrerelease().tryProcess(range)).isEqualTo(expectedString);
     }
 
     static Stream<Arguments> shouldParseHyphenRangeIncludePrerelease() {
         return Stream.of(
-                arguments("1.2.3 - 2.3.4", ">=1.2.3 <=2.3.4-0"),
-                arguments("1.2 - 2.3.4", ">=1.2.0 <=2.3.4-0"),
-                arguments("1 - 2.3.4", ">=1.0.0 <=2.3.4-0"),
+                arguments("1.2.3 - 2.3.4", ">=1.2.3 <2.3.5-0"),
+                arguments("1.2 - 2.3.4", ">=1.2.0 <2.3.5-0"),
+                arguments("1 - 2.3.4", ">=1.0.0 <2.3.5-0"),
                 arguments("1.2.3 - 2.3", ">=1.2.3 <2.4.0-0"),
                 arguments("1.2.3 - 2", ">=1.2.3 <3.0.0-0"),
-                arguments("1.2.3-alpha - 2.1.4-beta", ">=1.2.3-alpha <2.1.4-beta"),
-                arguments("1.2 - 2.1.4-beta", ">=1.2.0 <2.1.4-beta"),
-                arguments("1.2.3-alpha - 2.1.4", ">=1.2.3-alpha <2.1.4-0"),
+                arguments("1.2.3-alpha - 2.1.4-beta", ">=1.2.3-alpha <=2.1.4-beta"),
+                arguments("1.2 - 2.1.4-beta", ">=1.2.0 <=2.1.4-beta"),
+                arguments("1.2.3-alpha - 2.1.4", ">=1.2.3-alpha <2.1.5-0"),
                 arguments("INVALID", null)
         );
     }

--- a/src/test/java/org/semver4j/internal/range/processor/IvyProcessorTest.java
+++ b/src/test/java/org/semver4j/internal/range/processor/IvyProcessorTest.java
@@ -15,7 +15,7 @@ class IvyProcessorTest {
     @ParameterizedTest
     @MethodSource
     void shouldProcessIvyRanges(String range, String expected) {
-        assertThat(ivyProcessor.tryProcess(range)).isEqualTo(expected);
+        assertThat(ivyProcessor.process(range, false)).isEqualTo(expected);
     }
 
     static Stream<Arguments> shouldProcessIvyRanges() {
@@ -43,7 +43,7 @@ class IvyProcessorTest {
     @ParameterizedTest
     @MethodSource
     void shouldProcessIvyRangesIncludePrerelease(String range, String expected) {
-        assertThat(ivyProcessor.includePrerelease().tryProcess(range)).isEqualTo(expected);
+        assertThat(ivyProcessor.process(range, true)).isEqualTo(expected);
     }
 
     static Stream<Arguments> shouldProcessIvyRangesIncludePrerelease() {

--- a/src/test/java/org/semver4j/internal/range/processor/IvyProcessorTest.java
+++ b/src/test/java/org/semver4j/internal/range/processor/IvyProcessorTest.java
@@ -39,4 +39,32 @@ class IvyProcessorTest {
                 arguments("INVALID", null)
         );
     }
+
+    @ParameterizedTest
+    @MethodSource
+    void shouldProcessIvyRangesIncludePrerelease(String range, String expected) {
+        assertThat(ivyProcessor.includePrerelease().tryProcess(range)).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> shouldProcessIvyRangesIncludePrerelease() {
+        return Stream.of(
+                arguments("[1.0,2.0]", ">=1.0.0 <=2.0.0"),
+                arguments("[1.0,2.0[", ">=1.0.0 <2.0.0"),
+                arguments("]1.0,2.0]", ">1.0.0 <=2.0.0"),
+                arguments("]1.0,2.0[", ">1.0.0 <2.0.0"),
+                arguments("[1.0,)", ">=1.0.0"),
+                arguments("]1.0,)", ">1.0.0"),
+                arguments("(,2.0]", "<=2.0.0"),
+                arguments("(,2.0[", "<2.0.0"),
+                arguments("[1.0.1,2.0.1]", ">=1.0.1 <=2.0.1"),
+                arguments("]1.0.1,2.0.1]", ">1.0.1 <=2.0.1"),
+                arguments("[1.0.1,2.0.1[", ">=1.0.1 <2.0.1"),
+                arguments("]1.0.1,2.0.1[", ">1.0.1 <2.0.1"),
+                arguments("[1.0,2.0.1]", ">=1.0.0 <=2.0.1"),
+                arguments("[1.0.1,2.0]", ">=1.0.1 <=2.0.0"),
+                arguments("latest", ">=0.0.0-0"),
+                arguments("latest.integration", ">=0.0.0-0"),
+                arguments("INVALID", null)
+        );
+    }
 }

--- a/src/test/java/org/semver4j/internal/range/processor/ProcessorTest.java
+++ b/src/test/java/org/semver4j/internal/range/processor/ProcessorTest.java
@@ -1,6 +1,5 @@
 package org.semver4j.internal.range.processor;
 
-import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -9,26 +8,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ProcessorTest {
     @Test
     void nonNullProcessGetsReturned() {
-        Processor nonNullResultProcessor = new Processor() {
-            @Override
-            @Nullable
-            public String tryProcess(String range) {
-                return "RESULT";
-            }
-        };
+        Processor nonNullResultProcessor = (range, includePrerelease) -> "RESULT";
 
         assertThat(nonNullResultProcessor.process("RANGE")).isEqualTo("RESULT");
     }
 
     @Test
     void nullProcessDoesNotGetReturned() {
-        Processor nullResultProcessor = new Processor() {
-            @Override
-            @Nullable
-            public String tryProcess(String range) {
-                return null;
-            }
-        };
+        Processor nullResultProcessor = (range, includePrerelease) -> null;
 
         assertThat(nullResultProcessor.process("RANGE")).isEqualTo("RANGE");
     }

--- a/src/test/java/org/semver4j/internal/range/processor/TildeProcessorTest.java
+++ b/src/test/java/org/semver4j/internal/range/processor/TildeProcessorTest.java
@@ -15,7 +15,7 @@ class TildeProcessorTest {
     @ParameterizedTest
     @MethodSource
     void shouldParseTildeRange(String range, String expectedString) {
-        assertThat(tildeProcessor.tryProcess(range)).isEqualTo(expectedString);
+        assertThat(tildeProcessor.process(range, false)).isEqualTo(expectedString);
     }
 
     static Stream<Arguments> shouldParseTildeRange() {
@@ -31,7 +31,7 @@ class TildeProcessorTest {
     @ParameterizedTest
     @MethodSource
     void shouldParseTildeRangeIncludePrerelease(String range, String expectedString) {
-        assertThat(tildeProcessor.includePrerelease().tryProcess(range)).isEqualTo(expectedString);
+        assertThat(tildeProcessor.process(range, true)).isEqualTo(expectedString);
     }
 
     static Stream<Arguments> shouldParseTildeRangeIncludePrerelease() {

--- a/src/test/java/org/semver4j/internal/range/processor/TildeProcessorTest.java
+++ b/src/test/java/org/semver4j/internal/range/processor/TildeProcessorTest.java
@@ -36,7 +36,7 @@ class TildeProcessorTest {
 
     static Stream<Arguments> shouldParseTildeRangeIncludePrerelease() {
         return Stream.of(
-                arguments("~1.2.3", ">=1.2.3-0 <1.3.0-0"),
+                arguments("~1.2.3", ">=1.2.3 <1.3.0-0"),
                 arguments("~1.2", ">=1.2.0-0 <1.3.0-0"),
                 arguments("~1", ">=1.0.0-0 <2.0.0-0"),
                 arguments("~1.2.3-alpha", ">=1.2.3-alpha <1.3.0-0"),

--- a/src/test/java/org/semver4j/internal/range/processor/TildeProcessorTest.java
+++ b/src/test/java/org/semver4j/internal/range/processor/TildeProcessorTest.java
@@ -27,4 +27,20 @@ class TildeProcessorTest {
                 arguments("INVALID", null)
         );
     }
+
+    @ParameterizedTest
+    @MethodSource
+    void shouldParseTildeRangeIncludePrerelease(String range, String expectedString) {
+        assertThat(tildeProcessor.includePrerelease().tryProcess(range)).isEqualTo(expectedString);
+    }
+
+    static Stream<Arguments> shouldParseTildeRangeIncludePrerelease() {
+        return Stream.of(
+                arguments("~1.2.3", ">=1.2.3-0 <1.3.0-0"),
+                arguments("~1.2", ">=1.2.0-0 <1.3.0-0"),
+                arguments("~1", ">=1.0.0-0 <2.0.0-0"),
+                arguments("~1.2.3-alpha", ">=1.2.3-alpha <1.3.0-0"),
+                arguments("INVALID", null)
+        );
+    }
 }

--- a/src/test/java/org/semver4j/internal/range/processor/XRangeProcessorTest.java
+++ b/src/test/java/org/semver4j/internal/range/processor/XRangeProcessorTest.java
@@ -15,7 +15,7 @@ class XRangeProcessorTest {
     @ParameterizedTest
     @MethodSource
     void shouldParseXRange(String range, String expectedString) {
-        assertThat(xRangeProcessor.tryProcess(range)).isEqualTo(expectedString);
+        assertThat(xRangeProcessor.process(range, false)).isEqualTo(expectedString);
     }
 
     static Stream<Arguments> shouldParseXRange() {
@@ -39,7 +39,7 @@ class XRangeProcessorTest {
     @ParameterizedTest
     @MethodSource
     void shouldParseXRangeIncludePrerelease(String range, String expectedString) {
-        assertThat(xRangeProcessor.includePrerelease().tryProcess(range)).isEqualTo(expectedString);
+        assertThat(xRangeProcessor.process(range, true)).isEqualTo(expectedString);
     }
 
     static Stream<Arguments> shouldParseXRangeIncludePrerelease() {

--- a/src/test/java/org/semver4j/internal/range/processor/XRangeProcessorTest.java
+++ b/src/test/java/org/semver4j/internal/range/processor/XRangeProcessorTest.java
@@ -26,9 +26,35 @@ class XRangeProcessorTest {
                 arguments("<=1.2.X", "<1.3.0"),
                 arguments(">=1.2.X", ">=1.2.0"),
                 arguments(">=1.X.X", ">=1.0.0"),
+                arguments("<1.X.X", "<1.0.0"),
+                arguments("<1.2.X", "<1.2.0"),
                 arguments("1.X", ">=1.0.0 <2.0.0"),
                 arguments("1.2.X", ">=1.2.0 <1.3.0"),
                 arguments("=1.2.X", ">=1.2.0 <1.3.0"),
+                arguments(">=1.2.3 <2.0.0", ">=1.2.3 <2.0.0"),
+                arguments("INVALID", null)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void shouldParseXRangeIncludePrerelease(String range, String expectedString) {
+        assertThat(xRangeProcessor.includePrerelease().tryProcess(range)).isEqualTo(expectedString);
+    }
+
+    static Stream<Arguments> shouldParseXRangeIncludePrerelease() {
+        return Stream.of(
+                arguments(">1.X.X", ">=2.0.0-0"),
+                arguments(">1.2.X", ">=1.3.0-0"),
+                arguments("<=1.X.X", "<2.0.0-0"),
+                arguments("<=1.2.X", "<1.3.0-0"),
+                arguments(">=1.2.X", ">=1.2.0-0"),
+                arguments(">=1.X.X", ">=1.0.0-0"),
+                arguments("<1.X.X", "<1.0.0-0"),
+                arguments("<1.2.X", "<1.2.0-0"),
+                arguments("1.X", ">=1.0.0-0 <2.0.0-0"),
+                arguments("1.2.X", ">=1.2.0-0 <1.3.0-0"),
+                arguments("=1.2.X", ">=1.2.0-0 <1.3.0-0"),
                 arguments(">=1.2.3 <2.0.0", ">=1.2.3 <2.0.0"),
                 arguments("INVALID", null)
         );


### PR DESCRIPTION
Fixes https://github.com/semver4j/semver4j/issues/29

Adds the functionality equivalent of the `--include-prerelease` flag that will allow for including prerelease versions by default defined in the node semver repo [here](https://github.com/npm/node-semver?tab=readme-ov-file#functions) . The feature is accessible through a new method `Semver.satisfies(String range, boolean includePrerelease)`. All public methods will have `include-prerelease` default to false to maintain backwards compatibility.

Some of the processors are updated to be able to handle advanced ranges properly, as discussed in [this issue](https://github.com/npm/node-semver/commit/c44e124d045f246e5adfe8d18185edcb0fc311a1). Architecturally, `Processor` is changed from an interface to an abstract class to better handle some common state.

To include proper support for `--include-prerelease`, we need to add some additional logic for appending a prerelease identifier to certain ranges. For example, by default, `1.x` gets translated to `>=1.0.0 <2.0.0`. If we just used this same exact logic when considering prereleases, it will not work — `1.0.0-beta` will not satisfy the range, and `2.0.0-beta` will. So the actual correct range would then be `>=1.0.0-0 <2.0.0-0`, where `0` is the lowest possible prerelease identifier.
However, note that we cannot just change the range to always be `>-1.0.0-0 <2.0.0-0`, because that would mean anything with a prerelease identifier would satisfy the range, even if `--include-prerelease` is not set. This has to do with how prerelease versions interact with comparators, as defined [here](https://docs.npmjs.com/cli/v6/using-npm/semver#prerelease-tags).

Something else that might be noticed is that, with `--include-prerelease`, `^1.2.3` translates to `>=1.2.3 <2.0.0-0`, whereas `^1.2` translates to `>=1.2.3-0 <2.0.0-0`. This has to do with how [x ranges are defined](https://docs.npmjs.com/cli/v6/using-npm/semver#x-ranges-12x-1x-12-). Specifically, the definition is that:
- A missing patch version will be a range that matches the major and minor version
- A missing minor version will be a range that matches the major version

By this logic then, the lowest version that satisfies `1.2.3` is just `1.2.3` (it just so happens to be the only version that satisfies that range, since a range that is a version is just satisfied by the version), while the lowest version that satisfies `1.2` is `1.2.0-0`. This is why in Tilde, Caret, and Hyphen ranges, we have the lower bound of the range use the `0` prerelease identifier if a minor or patch version is not specified. 
