### PR TITLE
Replace nullness annotations with JSpecify

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>5.11.3</version>
@@ -63,12 +68,6 @@
             <artifactId>mockito-core</artifactId>
             <version>5.14.2</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jetbrains</groupId>
-            <artifactId>annotations</artifactId>
-            <version>26.0.1</version>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/semver4j/Range.java
+++ b/src/main/java/org/semver4j/Range.java
@@ -1,7 +1,7 @@
 package org.semver4j;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Locale;
 import java.util.Objects;
@@ -12,22 +12,20 @@ import static java.util.Arrays.stream;
 /**
  * Represents single range item.
  */
+@NullMarked
 public class Range {
-    @NotNull
     private final Semver rangeVersion;
-    @NotNull
     private final RangeOperator rangeOperator;
 
-    public Range(@NotNull final Semver rangeVersion, @NotNull final RangeOperator rangeOperator) {
+    public Range(final Semver rangeVersion, final RangeOperator rangeOperator) {
         this.rangeVersion = rangeVersion;
         this.rangeOperator = rangeOperator;
     }
 
-    public Range(@NotNull final String rangeVersion, @NotNull final RangeOperator rangeOperator) {
+    public Range(final String rangeVersion, final RangeOperator rangeOperator) {
         this(new Semver(rangeVersion), rangeOperator);
     }
 
-    @NotNull
     public Semver getRangeVersion() {
         return rangeVersion;
     }
@@ -48,7 +46,7 @@ public class Range {
      * @return {@code true} if range is satisfied by version, {@code false} otherwise
      * @see #isSatisfiedBy(Semver)
      */
-    public boolean isSatisfiedBy(@NotNull final String version) {
+    public boolean isSatisfiedBy(final String version) {
         return isSatisfiedBy(new Semver(version));
     }
 
@@ -59,7 +57,7 @@ public class Range {
      * @return {@code true} if range is satisfied by version, {@code false} otherwise
      * @see #isSatisfiedBy(String)
      */
-    public boolean isSatisfiedBy(@NotNull final Semver version) {
+    public boolean isSatisfiedBy(final Semver version) {
         switch (rangeOperator) {
             case EQ:
                 return version.isEquivalentTo(rangeVersion);
@@ -77,7 +75,7 @@ public class Range {
     }
 
     @Override
-    public boolean equals(@Nullable final Object o) {
+    public boolean equals(final @Nullable Object o) {
         if (this == o) {
             return true;
         }
@@ -94,7 +92,6 @@ public class Range {
     }
 
     @Override
-    @NotNull
     public String toString() {
         return rangeOperator.asString() + rangeVersion;
     }
@@ -126,10 +123,9 @@ public class Range {
         GTE(">="),
         ;
 
-        @NotNull
         private final String string;
 
-        RangeOperator(@NotNull final String string) {
+        RangeOperator(final String string) {
             this.string = string;
         }
 
@@ -138,13 +134,11 @@ public class Range {
          *
          * @return range operator as string
          */
-        @NotNull
         public String asString() {
             return string;
         }
 
-        @NotNull
-        public static RangeOperator value(@NotNull final String string) {
+        public static RangeOperator value(final String string) {
             if (string.isEmpty()) {
                 return EQ;
             }

--- a/src/main/java/org/semver4j/RangesExpression.java
+++ b/src/main/java/org/semver4j/RangesExpression.java
@@ -1,9 +1,8 @@
 package org.semver4j;
 
-import org.jetbrains.annotations.NotNull;
-
 import java.util.ArrayList;
 import java.util.List;
+import org.jspecify.annotations.NullMarked;
 
 import static org.semver4j.Range.RangeOperator.*;
 
@@ -25,29 +24,26 @@ import static org.semver4j.Range.RangeOperator.*;
  *
  * @since 4.2.0
  */
+@NullMarked
 @SuppressWarnings("checkstyle:DeclarationOrder")
 public class RangesExpression {
-    @NotNull
     private final RangesList rangesList = new RangesList();
 
-    @NotNull
-    private final List<@NotNull Range> andOperationRanges = new ArrayList<>();
+    private final List<Range> andOperationRanges = new ArrayList<>();
 
     /**
      * Expression for equal range item.
      *
      * @param version should be a valid semver string
      */
-    @NotNull
-    public static RangesExpression equal(@NotNull final String version) {
+    public static RangesExpression equal(final String version) {
         return equal(new Semver(version));
     }
 
     /**
      * Expression for equal range item.
      */
-    @NotNull
-    public static RangesExpression equal(@NotNull final Semver version) {
+    public static RangesExpression equal(final Semver version) {
         return new RangesExpression(new Range(version, EQ));
     }
 
@@ -56,16 +52,14 @@ public class RangesExpression {
      *
      * @param version should be a valid semver string
      */
-    @NotNull
-    public static RangesExpression greater(@NotNull final String version) {
+    public static RangesExpression greater(final String version) {
         return greater(new Semver(version));
     }
 
     /**
      * Expression for greater range item.
      */
-    @NotNull
-    public static RangesExpression greater(@NotNull final Semver version) {
+    public static RangesExpression greater(final Semver version) {
         return new RangesExpression(new Range(version, GT));
     }
 
@@ -74,16 +68,14 @@ public class RangesExpression {
      *
      * @param version should be a valid semver string
      */
-    @NotNull
-    public static RangesExpression greaterOrEqual(@NotNull final String version) {
+    public static RangesExpression greaterOrEqual(final String version) {
         return greaterOrEqual(new Semver(version));
     }
 
     /**
      * Expression for greater or equal range item.
      */
-    @NotNull
-    public static RangesExpression greaterOrEqual(@NotNull final Semver version) {
+    public static RangesExpression greaterOrEqual(final Semver version) {
         return new RangesExpression(new Range(version, GTE));
     }
 
@@ -92,16 +84,14 @@ public class RangesExpression {
      *
      * @param version should be a valid semver string
      */
-    @NotNull
-    public static RangesExpression less(@NotNull final String version) {
+    public static RangesExpression less(final String version) {
         return less(new Semver(version));
     }
 
     /**
      * Expression for lee range item.
      */
-    @NotNull
-    public static RangesExpression less(@NotNull final Semver version) {
+    public static RangesExpression less(final Semver version) {
         return new RangesExpression(new Range(version, LT));
     }
 
@@ -110,28 +100,25 @@ public class RangesExpression {
      *
      * @param version should be a valid semver string
      */
-    @NotNull
-    public static RangesExpression lessOrEqual(@NotNull final String version) {
+    public static RangesExpression lessOrEqual(final String version) {
         return lessOrEqual(new Semver(version));
     }
 
     /**
      * Expression for less or equal range item.
      */
-    @NotNull
-    public static RangesExpression lessOrEqual(@NotNull final Semver version) {
+    public static RangesExpression lessOrEqual(final Semver version) {
         return new RangesExpression(new Range(version, LTE));
     }
 
-    RangesExpression(@NotNull final Range range) {
+    RangesExpression(final Range range) {
         andOperationRanges.add(range);
     }
 
     /**
      * Allows to join ranges using {@code AND} operator.
      */
-    @NotNull
-    public RangesExpression and(@NotNull final RangesExpression rangeExpression) {
+    public RangesExpression and(final RangesExpression rangeExpression) {
         RangesList rangesList = rangeExpression.get();
         List<List<Range>> lists = rangesList.get();
         for (List<Range> list : lists) {
@@ -146,13 +133,11 @@ public class RangesExpression {
     /**
      * Allows to join ranges using {@code OR} operator.
      */
-    @NotNull
-    public RangesExpression or(@NotNull final RangesExpression rangeExpression) {
+    public RangesExpression or(final RangesExpression rangeExpression) {
         flushAndClearAndOperationRangesToRangesList();
         return and(rangeExpression);
     }
 
-    @NotNull
     RangesList get() {
         if (!andOperationRanges.isEmpty()) {
             flushAndClearAndOperationRangesToRangesList();

--- a/src/main/java/org/semver4j/RangesList.java
+++ b/src/main/java/org/semver4j/RangesList.java
@@ -1,10 +1,9 @@
 package org.semver4j;
 
-import org.jetbrains.annotations.NotNull;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import org.jspecify.annotations.NullMarked;
 
 import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
@@ -39,20 +38,17 @@ import static java.util.stream.Collectors.joining;
  * </ul>
  * Any other versions <b>not satisfied</b> this range.
  */
+@NullMarked
 public class RangesList {
-    @NotNull
     private static final String OR_JOINER = " or ";
-    @NotNull
     private static final String AND_JOINER = " and ";
 
-    @NotNull
-    private final List<@NotNull List<@NotNull Range>> rangesList = new ArrayList<>();
+    private final List<List<Range>> rangesList = new ArrayList<>();
 
     /**
      * Add ranges to ranges list.
      */
-    @NotNull
-    public RangesList add(@NotNull final List<@NotNull Range> ranges) {
+    public RangesList add(final List<Range> ranges) {
         if (!ranges.isEmpty()) {
             rangesList.add(ranges);
         }
@@ -62,8 +58,7 @@ public class RangesList {
     /**
      * Return the list of range lists.
      */
-    @NotNull
-    public List<@NotNull List<@NotNull Range>> get() {
+    public List<List<Range>> get() {
         return rangesList;
     }
 
@@ -79,13 +74,12 @@ public class RangesList {
     /**
      * Check whether this ranges list is satisfied by version.
      */
-    public boolean isSatisfiedBy(@NotNull final Semver version) {
+    public boolean isSatisfiedBy(final Semver version) {
         return rangesList.stream()
             .anyMatch(ranges -> isSingleSetOfRangesIsSatisfied(ranges, version));
     }
 
     @Override
-    @NotNull
     public String toString() {
         return rangesList.stream()
             .map(RangesList::formatRanges)
@@ -93,8 +87,7 @@ public class RangesList {
             .replaceAll("^\\(([^()]+)\\)$", "$1");
     }
 
-    @NotNull
-    private static String formatRanges(@NotNull final List<@NotNull Range> ranges) {
+    private static String formatRanges(final List<Range> ranges) {
         String representation = ranges.stream()
             .map(Range::toString)
             .collect(joining(AND_JOINER));
@@ -106,7 +99,7 @@ public class RangesList {
         return format(Locale.ROOT, "(%s)", representation);
     }
 
-    private static boolean isSingleSetOfRangesIsSatisfied(@NotNull final List<@NotNull Range> ranges, @NotNull final Semver version) {
+    private static boolean isSingleSetOfRangesIsSatisfied(final List<Range> ranges, final Semver version) {
         for (Range range : ranges) {
             if (!range.isSatisfiedBy(version)) {
                 return false;

--- a/src/main/java/org/semver4j/RangesListFactory.java
+++ b/src/main/java/org/semver4j/RangesListFactory.java
@@ -1,24 +1,20 @@
 package org.semver4j;
 
-import org.jetbrains.annotations.NotNull;
-
-import static org.jetbrains.annotations.ApiStatus.AvailableSince;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Class for create a {@link RangesList} object.
  */
+@NullMarked
 public class RangesListFactory {
-    @NotNull
-    public static RangesList create(@NotNull final String range) {
+    public static RangesList create(final String range) {
         return new RangesString().get(range);
     }
 
     /**
      * @since 4.2.0
      */
-    @NotNull
-    @AvailableSince("4.2.0")
-    public static RangesList create(@NotNull final RangesExpression rangeExpressions) {
+    public static RangesList create(final RangesExpression rangeExpressions) {
         return rangeExpressions.get();
     }
 }

--- a/src/main/java/org/semver4j/RangesString.java
+++ b/src/main/java/org/semver4j/RangesString.java
@@ -1,6 +1,6 @@
 package org.semver4j;
 
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NullMarked;
 import org.semver4j.internal.range.RangeProcessorPipeline;
 import org.semver4j.internal.range.processor.AllVersionsProcessor;
 import org.semver4j.internal.range.processor.CaretProcessor;
@@ -18,12 +18,10 @@ import static java.util.regex.Pattern.compile;
 import static org.semver4j.internal.Tokenizers.COMPARATOR;
 import static org.semver4j.internal.range.RangeProcessorPipeline.startWith;
 
+@NullMarked
 class RangesString {
-    @NotNull
     private static final Pattern splitterPattern = compile("(\\s*)([<>]?=?)\\s*");
-    @NotNull
     private static final Pattern comparatorPattern = compile(COMPARATOR);
-    @NotNull
     private static final RangeProcessorPipeline rangeProcessorPipeline = startWith(new AllVersionsProcessor())
             .addProcessor(new IvyProcessor())
             .addProcessor(new HyphenProcessor())
@@ -31,8 +29,7 @@ class RangesString {
             .addProcessor(new TildeProcessor())
             .addProcessor(new XRangeProcessor());
 
-    @NotNull
-    RangesList get(@NotNull String range) {
+    RangesList get(String range) {
         RangesList rangesList = new RangesList();
 
         range = range.trim();
@@ -48,19 +45,16 @@ class RangesString {
         return rangesList;
     }
 
-    @NotNull
-    private static String stripWhitespacesBetweenRangeOperator(@NotNull final String rangeSection) {
+    private static String stripWhitespacesBetweenRangeOperator(final String rangeSection) {
         Matcher matcher = splitterPattern.matcher(rangeSection);
         return matcher.replaceAll("$1$2").trim();
     }
 
-    @NotNull
-    private static String applyProcessors(@NotNull final String range) {
+    private static String applyProcessors(final String range) {
         return rangeProcessorPipeline.process(range);
     }
 
-    @NotNull
-    private static List<@NotNull Range> addRanges(@NotNull final String range) {
+    private static List<Range> addRanges(final String range) {
         List<Range> ranges = new ArrayList<>();
 
         String[] parsedRanges = range.split("\\s+");

--- a/src/main/java/org/semver4j/Semver.java
+++ b/src/main/java/org/semver4j/Semver.java
@@ -1,7 +1,7 @@
 package org.semver4j;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.semver4j.internal.Comparator;
 import org.semver4j.internal.*;
 import org.semver4j.internal.StrictParser.Version;
@@ -18,25 +18,21 @@ import static java.util.Objects.requireNonNull;
  * Semver is a tool that provides useful methods to manipulate versions that follow the "semantic versioning"
  * specification (see <a href="http://semver.org">semver.org</a>).
  */
+@NullMarked
 public class Semver implements Comparable<Semver> {
-    @NotNull
     public static final Semver ZERO = new Semver("0.0.0");
 
-    @NotNull
     private final String originalVersion;
 
     private final int major;
     private final int minor;
     private final int patch;
-    @NotNull
-    private final List<@NotNull String> preRelease;
-    @NotNull
-    private final List<@NotNull String> build;
+    private final List<String> preRelease;
+    private final List<String> build;
 
-    @NotNull
     private final String version;
 
-    public Semver(@NotNull final String version) {
+    public Semver(final String version) {
         this.originalVersion = version.trim();
 
         Version parsedVersion = StrictParser.parse(this.originalVersion);
@@ -62,8 +58,7 @@ public class Semver implements Comparable<Semver> {
      * @param version version string to parse
      * @return {@link Semver} when done, {@code null} otherwise
      */
-    @Nullable
-    public static Semver parse(@Nullable final String version) {
+    public static @Nullable Semver parse(final @Nullable String version) {
         if (version == null) {
             return null;
         }
@@ -80,8 +75,7 @@ public class Semver implements Comparable<Semver> {
      * @param version version to coerce
      * @return {@link Semver} if can coerce version, {@code null} otherwise
      */
-    @Nullable
-    public static Semver coerce(@Nullable final String version) {
+    public static @Nullable Semver coerce(final @Nullable String version) {
         if (version == null) {
             return null;
         }
@@ -101,7 +95,7 @@ public class Semver implements Comparable<Semver> {
      * @param version version to check
      * @return {@code true} if is valid version, {@code false} otherwise
      */
-    public static boolean isValid(@Nullable final String version) {
+    public static boolean isValid(final @Nullable String version) {
         return parse(version) != null;
     }
 
@@ -123,7 +117,6 @@ public class Semver implements Comparable<Semver> {
      * @return basic {@link Semver} object
      * @since 5.3.0
      */
-    @NotNull
     public static Semver of(int major, int minor, int patch) {
         return new Builder()
                 .withMajor(major)
@@ -137,7 +130,6 @@ public class Semver implements Comparable<Semver> {
      *
      * @return version
      */
-    @NotNull
     public String getVersion() {
         return version;
     }
@@ -178,8 +170,7 @@ public class Semver implements Comparable<Semver> {
      *
      * @return the pre-release of the version
      */
-    @NotNull
-    public List<@NotNull String> getPreRelease() {
+    public List<String> getPreRelease() {
         return preRelease;
     }
 
@@ -189,8 +180,7 @@ public class Semver implements Comparable<Semver> {
      *
      * @return the build of the version
      */
-    @NotNull
-    public List<@NotNull String> getBuild() {
+    public List<String> getBuild() {
         return build;
     }
 
@@ -210,7 +200,6 @@ public class Semver implements Comparable<Semver> {
      *
      * @return new incremented semver
      */
-    @NotNull
     public Semver nextMajor() {
         return Modifier.nextMajor(this);
     }
@@ -220,7 +209,6 @@ public class Semver implements Comparable<Semver> {
      *
      * @return new incremented semver
      */
-    @NotNull
     public Semver withIncMajor() {
         return withIncMajor(1);
     }
@@ -231,7 +219,6 @@ public class Semver implements Comparable<Semver> {
      * @param number how many major should be incremented
      * @return new incremented semver
      */
-    @NotNull
     public Semver withIncMajor(int number) {
         return Modifier.withIncMajor(this, number);
     }
@@ -241,7 +228,6 @@ public class Semver implements Comparable<Semver> {
      *
      * @return new incremented semver
      */
-    @NotNull
     public Semver nextMinor() {
         return Modifier.nextMinor(this);
     }
@@ -251,7 +237,6 @@ public class Semver implements Comparable<Semver> {
      *
      * @return new incremented semver
      */
-    @NotNull
     public Semver withIncMinor() {
         return withIncMinor(1);
     }
@@ -262,7 +247,6 @@ public class Semver implements Comparable<Semver> {
      * @param number how many minor should be incremented
      * @return new incremented semver
      */
-    @NotNull
     public Semver withIncMinor(int number) {
         return Modifier.withIncMinor(this, number);
     }
@@ -272,7 +256,6 @@ public class Semver implements Comparable<Semver> {
      *
      * @return new incremented semver
      */
-    @NotNull
     public Semver nextPatch() {
         return Modifier.nextPatch(this);
     }
@@ -282,7 +265,6 @@ public class Semver implements Comparable<Semver> {
      *
      * @return new incremented semver
      */
-    @NotNull
     public Semver withIncPatch() {
         return withIncPatch(1);
     }
@@ -293,7 +275,6 @@ public class Semver implements Comparable<Semver> {
      * @param number how many patch should be incremented
      * @return new incremented semver
      */
-    @NotNull
     public Semver withIncPatch(int number) {
         return Modifier.withIncPatch(this, number);
     }
@@ -304,8 +285,7 @@ public class Semver implements Comparable<Semver> {
      * @param preRelease version to set
      * @return semver with new pre-release
      */
-    @NotNull
-    public Semver withPreRelease(@NotNull final String preRelease) {
+    public Semver withPreRelease(final String preRelease) {
         return Modifier.withPreRelease(this, preRelease);
     }
 
@@ -315,8 +295,7 @@ public class Semver implements Comparable<Semver> {
      * @param build version to set
      * @return semver with new build
      */
-    @NotNull
-    public Semver withBuild(@NotNull final String build) {
+    public Semver withBuild(final String build) {
         return Modifier.withBuild(this, build);
     }
 
@@ -325,7 +304,6 @@ public class Semver implements Comparable<Semver> {
      *
      * @return semver without pre-release
      */
-    @NotNull
     public Semver withClearedPreRelease() {
         return Modifier.withClearedPreRelease(this);
     }
@@ -335,7 +313,6 @@ public class Semver implements Comparable<Semver> {
      *
      * @return semver without build
      */
-    @NotNull
     public Semver withClearedBuild() {
         return Modifier.withClearedBuild(this);
     }
@@ -345,20 +322,19 @@ public class Semver implements Comparable<Semver> {
      *
      * @return semver without pre-release and build
      */
-    @NotNull
     public Semver withClearedPreReleaseAndBuild() {
         return Modifier.withClearedPreReleaseAndBuild(this);
     }
 
     @Override
-    public int compareTo(@NotNull final Semver other) {
+    public int compareTo(final Semver other) {
         return Comparator.compareTo(this, other);
     }
 
     /**
      * Checks whether the given version is API compatible with this version.
      */
-    public boolean isApiCompatible(@NotNull final String version) {
+    public boolean isApiCompatible(final String version) {
         return diff(version).ordinal() < VersionDiff.MAJOR.ordinal();
     }
 
@@ -366,7 +342,7 @@ public class Semver implements Comparable<Semver> {
      * Checks whether the given version is API compatible with this version.
      */
     @SuppressWarnings("unused")
-    public boolean isApiCompatible(@NotNull final Semver version) {
+    public boolean isApiCompatible(final Semver version) {
         return diff(version).ordinal() < VersionDiff.MAJOR.ordinal();
     }
 
@@ -377,7 +353,7 @@ public class Semver implements Comparable<Semver> {
      * @return {@code true} if the current version is greater than the provided version, {@code false} otherwise
      * @see #isGreaterThan(Semver)
      */
-    public boolean isGreaterThan(@NotNull final String version) {
+    public boolean isGreaterThan(final String version) {
         return isGreaterThan(new Semver(version));
     }
 
@@ -388,7 +364,7 @@ public class Semver implements Comparable<Semver> {
      * @return {@code true} if the current version is greater than the provided version, {@code false} otherwise
      * @see #isGreaterThan(String)
      */
-    public boolean isGreaterThan(@NotNull final Semver version) {
+    public boolean isGreaterThan(final Semver version) {
         return compareTo(version) > 0;
     }
 
@@ -399,7 +375,7 @@ public class Semver implements Comparable<Semver> {
      * @return {@code true} if the current version is greater than or equal to the provided version, {@code false} otherwise
      * @see #isGreaterThanOrEqualTo(Semver)
      */
-    public boolean isGreaterThanOrEqualTo(@NotNull final String version) {
+    public boolean isGreaterThanOrEqualTo(final String version) {
         return isGreaterThanOrEqualTo(new Semver(version));
     }
 
@@ -410,7 +386,7 @@ public class Semver implements Comparable<Semver> {
      * @return {@code true} if the current version is greater than or equal to the provided version, {@code false} otherwise
      * @see #isLowerThan(String)
      */
-    public boolean isGreaterThanOrEqualTo(@NotNull final Semver version) {
+    public boolean isGreaterThanOrEqualTo(final Semver version) {
         return compareTo(version) >= 0;
     }
 
@@ -421,7 +397,7 @@ public class Semver implements Comparable<Semver> {
      * @return {@code true} if the current version is lower than the provided version, {@code false} otherwise
      * @see #isLowerThan(Semver)
      */
-    public boolean isLowerThan(@NotNull final String version) {
+    public boolean isLowerThan(final String version) {
         return isLowerThan(new Semver(version));
     }
 
@@ -432,7 +408,7 @@ public class Semver implements Comparable<Semver> {
      * @return {@code true} if the current version is lower than the provided version, {@code false} otherwise
      * @see #isLowerThan(String)
      */
-    public boolean isLowerThan(@NotNull final Semver version) {
+    public boolean isLowerThan(final Semver version) {
         return compareTo(version) < 0;
     }
 
@@ -443,7 +419,7 @@ public class Semver implements Comparable<Semver> {
      * @return {@code true} if the current version is lower than or equal to the provided version, {@code false} otherwise
      * @see #isLowerThanOrEqualTo(Semver)
      */
-    public boolean isLowerThanOrEqualTo(@NotNull final String version) {
+    public boolean isLowerThanOrEqualTo(final String version) {
         return isLowerThanOrEqualTo(new Semver(version));
     }
 
@@ -454,7 +430,7 @@ public class Semver implements Comparable<Semver> {
      * @return {@code true} if the current version is lower than or equal to the provided version, {@code false} otherwise
      * @see #isLowerThanOrEqualTo(String)
      */
-    public boolean isLowerThanOrEqualTo(@NotNull final Semver version) {
+    public boolean isLowerThanOrEqualTo(final Semver version) {
         return compareTo(version) <= 0;
     }
 
@@ -465,7 +441,7 @@ public class Semver implements Comparable<Semver> {
      * @return {@code true} if the current version equals the provided version, {@code false} otherwise
      * @see #isEqualTo(Semver)
      */
-    public boolean isEqualTo(@NotNull final String version) {
+    public boolean isEqualTo(final String version) {
         return isEqualTo(new Semver(version));
     }
 
@@ -476,7 +452,7 @@ public class Semver implements Comparable<Semver> {
      * @return {@code true} if the current version equals the provided version, {@code false} otherwise
      * @see #isEqualTo(String)
      */
-    public boolean isEqualTo(@NotNull final Semver version) {
+    public boolean isEqualTo(final Semver version) {
         return equals(version);
     }
 
@@ -487,7 +463,7 @@ public class Semver implements Comparable<Semver> {
      * @return {@code true} if the current version equals the provided version (build excluded), {@code false} otherwise
      * @see #isEquivalentTo(Semver)
      */
-    public boolean isEquivalentTo(@NotNull final String version) {
+    public boolean isEquivalentTo(final String version) {
         return isEquivalentTo(new Semver(version));
     }
 
@@ -498,7 +474,7 @@ public class Semver implements Comparable<Semver> {
      * @return {@code true} if the current version equals the provided version (build excluded), {@code false} otherwise
      * @see #isEquivalentTo(String)
      */
-    public boolean isEquivalentTo(@NotNull final Semver version) {
+    public boolean isEquivalentTo(final Semver version) {
         return compareTo(version) == 0;
     }
 
@@ -511,8 +487,7 @@ public class Semver implements Comparable<Semver> {
      * @return the greatest difference
      * @see #diff(Semver)
      */
-    @NotNull
-    public VersionDiff diff(@NotNull final String version) {
+    public VersionDiff diff(final String version) {
         return diff(new Semver(version));
     }
 
@@ -525,8 +500,7 @@ public class Semver implements Comparable<Semver> {
      * @return the greatest difference
      * @see #diff(String)
      */
-    @NotNull
-    public VersionDiff diff(@NotNull final Semver version) {
+    public VersionDiff diff(final Semver version) {
         return Differ.diff(this, version);
     }
 
@@ -538,7 +512,7 @@ public class Semver implements Comparable<Semver> {
      * @see #satisfies(RangesList)
      * @see #satisfies(RangesExpression)
      */
-    public boolean satisfies(@NotNull final String range) {
+    public boolean satisfies(final String range) {
         RangesList rangesList = RangesListFactory.create(range);
         return satisfies(rangesList);
     }
@@ -553,7 +527,7 @@ public class Semver implements Comparable<Semver> {
      * @see #satisfies(RangesList)
      * @since 4.2.0
      */
-    public boolean satisfies(@NotNull final RangesExpression rangesExpression) {
+    public boolean satisfies(final RangesExpression rangesExpression) {
         RangesList rangesList = RangesListFactory.create(rangesExpression);
         return satisfies(rangesList);
     }
@@ -566,7 +540,7 @@ public class Semver implements Comparable<Semver> {
      * @see #satisfies(String)
      * @see #satisfies(RangesExpression)
      */
-    public boolean satisfies(@NotNull final RangesList rangesList) {
+    public boolean satisfies(final RangesList rangesList) {
         return rangesList.isSatisfiedBy(this);
     }
 
@@ -578,7 +552,7 @@ public class Semver implements Comparable<Semver> {
     }
 
     @Override
-    public boolean equals(@Nullable final Object o) {
+    public boolean equals(final @Nullable Object o) {
         if (this == o) {
             return true;
         }
@@ -595,7 +569,6 @@ public class Semver implements Comparable<Semver> {
     }
 
     @Override
-    @NotNull
     public String toString() {
         return getVersion();
     }
@@ -641,36 +614,36 @@ public class Semver implements Comparable<Semver> {
         }
 
         @SuppressWarnings("unused")
-        public Builder withPreRelease(@NotNull String preRelease) {
+        public Builder withPreRelease(String preRelease) {
             requireNonNull(preRelease, "preRelease cannot be null");
             return withPreReleases(new String[]{preRelease});
         }
 
-        public Builder withPreReleases(@NotNull Collection<String> preReleases) {
+        public Builder withPreReleases(Collection<String> preReleases) {
             requireNonNull(preReleases, "preRelease cannot be null");
             this.preRelease = new ArrayList<>(preReleases);
             return this;
         }
 
-        public Builder withPreReleases(@NotNull String[] preReleases) {
+        public Builder withPreReleases(String[] preReleases) {
             requireNonNull(preReleases, "preRelease cannot be null");
             this.preRelease = Arrays.asList(preReleases);
             return this;
         }
 
         @SuppressWarnings("unused")
-        public Builder withBuild(@NotNull String build) {
+        public Builder withBuild(String build) {
             requireNonNull(build, "build cannot be null");
             return withBuilds(new String[]{build});
         }
 
-        public Builder withBuilds(@NotNull Collection<String> builds) {
+        public Builder withBuilds(Collection<String> builds) {
             requireNonNull(builds, "builds cannot be null");
             this.build = new ArrayList<>(builds);
             return this;
         }
 
-        public Builder withBuilds(@NotNull String[] builds) {
+        public Builder withBuilds(String[] builds) {
             requireNonNull(builds, "builds cannot be null");
             this.build = Arrays.asList(builds);
             return this;
@@ -679,7 +652,6 @@ public class Semver implements Comparable<Semver> {
         /**
          * Build a {@link Semver} object.
          */
-        @NotNull
         public Semver toSemver() {
             String version = toVersion();
             return new Semver(version);
@@ -690,7 +662,6 @@ public class Semver implements Comparable<Semver> {
          * It follows a semver specification which results in:
          * {@code 1.2.3-alpha+5bb76cdb}
          */
-        @NotNull
         public String toVersion() {
             String resultVersion = String.format(Locale.ROOT, "%d.%d.%d", major, minor, patch);
             if (!preRelease.isEmpty()) {

--- a/src/main/java/org/semver4j/Semver.java
+++ b/src/main/java/org/semver4j/Semver.java
@@ -58,7 +58,8 @@ public class Semver implements Comparable<Semver> {
      * @param version version string to parse
      * @return {@link Semver} when done, {@code null} otherwise
      */
-    public static @Nullable Semver parse(final @Nullable String version) {
+    @Nullable
+    public static Semver parse(final @Nullable String version) {
         if (version == null) {
             return null;
         }
@@ -75,7 +76,8 @@ public class Semver implements Comparable<Semver> {
      * @param version version to coerce
      * @return {@link Semver} if can coerce version, {@code null} otherwise
      */
-    public static @Nullable Semver coerce(final @Nullable String version) {
+    @Nullable
+    public static Semver coerce(final @Nullable String version) {
         if (version == null) {
             return null;
         }

--- a/src/main/java/org/semver4j/SemverException.java
+++ b/src/main/java/org/semver4j/SemverException.java
@@ -1,8 +1,11 @@
 package org.semver4j;
 
+import org.jspecify.annotations.NullMarked;
+
 /**
  * Thrown when something went wrong with parsing semver string.
  */
+@NullMarked
 public class SemverException extends IllegalArgumentException {
     public SemverException(String message) {
         super(message);

--- a/src/main/java/org/semver4j/internal/Coerce.java
+++ b/src/main/java/org/semver4j/internal/Coerce.java
@@ -1,7 +1,7 @@
 package org.semver4j.internal;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Locale;
 import java.util.Optional;
@@ -11,8 +11,8 @@ import java.util.regex.Pattern;
 import static java.lang.String.format;
 import static java.util.regex.Pattern.compile;
 
+@NullMarked
 public class Coerce {
-    @NotNull
     private static final Pattern PATTERN = compile(
         "(^|\\D)(\\d{1,16})(?:\\.(\\d{1,16}))?(?:\\.(\\d{1,16}))?(?:$|\\D)"
     );
@@ -20,8 +20,7 @@ public class Coerce {
     private Coerce() {
     }
 
-    @Nullable
-    public static String coerce(@NotNull final String version) {
+    public static @Nullable String coerce(final String version) {
         Matcher matcher = PATTERN.matcher(version);
 
         if (matcher.find()) {

--- a/src/main/java/org/semver4j/internal/Coerce.java
+++ b/src/main/java/org/semver4j/internal/Coerce.java
@@ -20,7 +20,8 @@ public class Coerce {
     private Coerce() {
     }
 
-    public static @Nullable String coerce(final String version) {
+    @Nullable
+    public static String coerce(final String version) {
         Matcher matcher = PATTERN.matcher(version);
 
         if (matcher.find()) {

--- a/src/main/java/org/semver4j/internal/Comparator.java
+++ b/src/main/java/org/semver4j/internal/Comparator.java
@@ -1,26 +1,26 @@
 package org.semver4j.internal;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.semver4j.Semver;
 
 import java.util.List;
 
 import static java.lang.Math.max;
 
+@NullMarked
 public class Comparator {
     private static final String ALL_DIGITS = "^\\d+$";
     private static final String CONTAINS_DIGITS = ".*\\d.*";
     private static final String TRAILING_DIGITS_EXTRACT = "(?<=\\D)(?=\\d)";
     private static final String LEADING_DIGITS_EXTRACT = "(?<=\\d)(?=\\D)";
 
-    @NotNull
     private static final String UNDEFINED_MARKER = "undef";
 
     private Comparator() {
     }
 
-    public static int compareTo(@NotNull final Semver version, @NotNull final Semver other) {
+    public static int compareTo(final Semver version, final Semver other) {
         int result = mainCompare(version, other);
         if (result == 0) {
             return preReleaseCompare(version, other);
@@ -28,7 +28,7 @@ public class Comparator {
         return result;
     }
 
-    private static int mainCompare(@NotNull final Semver version, @NotNull final Semver other) {
+    private static int mainCompare(final Semver version, final Semver other) {
         int majorCompare = Long.compare(version.getMajor(), other.getMajor());
         if (majorCompare == 0) {
             int minorCompare = Long.compare(version.getMinor(), other.getMinor());
@@ -42,7 +42,7 @@ public class Comparator {
         }
     }
 
-    private static int preReleaseCompare(@NotNull final Semver version, @NotNull final Semver other) {
+    private static int preReleaseCompare(final Semver version, final Semver other) {
         if (!version.getPreRelease().isEmpty() && other.getPreRelease().isEmpty()) {
             return -1;
         } else if (version.getPreRelease().isEmpty() && !other.getPreRelease().isEmpty()) {
@@ -76,7 +76,7 @@ public class Comparator {
         return 0;
     }
 
-    private static int compareIdentifiers(@NotNull final String a, @NotNull final String b) {
+    private static int compareIdentifiers(final String a, final String b) {
         // Only attempt to parse fully numeric string sequences so that we can avoid
         // raising a costly exception
         if (a.matches(ALL_DIGITS) && b.matches(ALL_DIGITS)) {
@@ -101,8 +101,7 @@ public class Comparator {
         return 0;
     }
 
-    @Nullable
-    private static Integer checkAlphanumericPrerelease(@NotNull final String a, @NotNull final String b) {
+    private static @Nullable Integer checkAlphanumericPrerelease(final String a, final String b) {
         String[] tokenArrA = a.split(TRAILING_DIGITS_EXTRACT);
         String[] tokenArrB = b.split(TRAILING_DIGITS_EXTRACT);
         if (tokenArrA.length != tokenArrB.length) {
@@ -128,8 +127,7 @@ public class Comparator {
         return null;
     }
 
-    @NotNull
-    private static String getString(final int i, @NotNull final List<@NotNull String> list) {
+    private static String getString(final int i, final List<String> list) {
         if (list.size() > i) {
             return list.get(i);
         } else {

--- a/src/main/java/org/semver4j/internal/Differ.java
+++ b/src/main/java/org/semver4j/internal/Differ.java
@@ -1,17 +1,17 @@
 package org.semver4j.internal;
 
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NullMarked;
 import org.semver4j.Semver;
 import org.semver4j.Semver.VersionDiff;
 
 import static org.semver4j.Semver.VersionDiff.*;
 
+@NullMarked
 public class Differ {
     private Differ() {
     }
 
-    @NotNull
-    public static VersionDiff diff(@NotNull final Semver version, @NotNull final Semver other) {
+    public static VersionDiff diff(final Semver version, final Semver other) {
         if (version.getMajor() != other.getMajor()) {
             return MAJOR;
         }

--- a/src/main/java/org/semver4j/internal/Modifier.java
+++ b/src/main/java/org/semver4j/internal/Modifier.java
@@ -1,6 +1,6 @@
 package org.semver4j.internal;
 
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NullMarked;
 import org.semver4j.Semver;
 
 import java.util.List;
@@ -10,6 +10,7 @@ import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 
+@NullMarked
 public class Modifier {
     private static final String FULL_FORMAT = "%d.%d.%d";
     private static final String MAJOR_FORMAT = "%d.0.0";
@@ -18,8 +19,7 @@ public class Modifier {
     private Modifier() {
     }
 
-    @NotNull
-    public static Semver nextMajor(@NotNull final Semver version) {
+    public static Semver nextMajor(final Semver version) {
         int nextMajor = version.getMajor();
 
         // Prerelease version 1.0.0-5 bumps to 1.0.0
@@ -31,14 +31,12 @@ public class Modifier {
         return new Semver(newVersion);
     }
 
-    @NotNull
-    public static Semver withIncMajor(@NotNull final Semver version, int number) {
+    public static Semver withIncMajor(final Semver version, int number) {
         String newVersion = createFullVersion(version, format(Locale.ROOT, FULL_FORMAT, (version.getMajor() + number), version.getMinor(), version.getPatch()), version.getPreRelease());
         return new Semver(newVersion);
     }
 
-    @NotNull
-    public static Semver nextMinor(@NotNull final Semver version) {
+    public static Semver nextMinor(final Semver version) {
         int nextMinor = version.getMinor();
 
         // Prerelease version 1.2.0-5 bumps to 1.2.0
@@ -50,14 +48,12 @@ public class Modifier {
         return new Semver(newVersion);
     }
 
-    @NotNull
-    public static Semver withIncMinor(@NotNull final Semver version, int number) {
+    public static Semver withIncMinor(final Semver version, int number) {
         String newVersion = createFullVersion(version, format(Locale.ROOT, FULL_FORMAT, version.getMajor(), (version.getMinor() + number), version.getPatch()), version.getPreRelease());
         return new Semver(newVersion);
     }
 
-    @NotNull
-    public static Semver nextPatch(@NotNull final Semver version) {
+    public static Semver nextPatch(final Semver version) {
         int newPatch = version.getPatch();
 
         // Prerelease version 1.2.0-5 bumps to 1.2.0
@@ -69,60 +65,52 @@ public class Modifier {
         return new Semver(newVersion);
     }
 
-    @NotNull
-    public static Semver withIncPatch(@NotNull final Semver version, int number) {
+    public static Semver withIncPatch(final Semver version, int number) {
         String newVersion = createFullVersion(version, format(Locale.ROOT, FULL_FORMAT, version.getMajor(), version.getMinor(), (version.getPatch() + number)), version.getPreRelease());
         return new Semver(newVersion);
     }
 
-    @NotNull
-    public static Semver withPreRelease(@NotNull final Semver version, @NotNull final String preRelease) {
+    public static Semver withPreRelease(final Semver version, final String preRelease) {
         List<String> newPreRelease = asList(preRelease.split("\\."));
 
         String newVersion = createFullVersion(version, format(Locale.ROOT, FULL_FORMAT, version.getMajor(), version.getMinor(), version.getPatch()), newPreRelease);
         return new Semver(newVersion);
     }
 
-    @NotNull
-    public static Semver withBuild(@NotNull final Semver version, @NotNull final String build) {
+    public static Semver withBuild(final Semver version, final String build) {
         List<String> newBuild = asList(build.split("\\."));
 
         String newVersion = createFullVersion(format(Locale.ROOT, FULL_FORMAT, version.getMajor(), version.getMinor(), version.getPatch()), version.getPreRelease(), newBuild);
         return new Semver(newVersion);
     }
 
-    @NotNull
-    public static Semver withClearedPreRelease(@NotNull final Semver version) {
+    public static Semver withClearedPreRelease(final Semver version) {
         String newVersion = createFullVersion(version, format(Locale.ROOT, FULL_FORMAT, version.getMajor(), version.getMinor(), version.getPatch()), emptyList());
         return new Semver(newVersion);
     }
 
-    @NotNull
-    public static Semver withClearedBuild(@NotNull final Semver version) {
+    public static Semver withClearedBuild(final Semver version) {
         String newVersion = createFullVersion(format(Locale.ROOT, FULL_FORMAT, version.getMajor(), version.getMinor(), version.getPatch()), version.getPreRelease(), emptyList());
         return new Semver(newVersion);
     }
 
-    @NotNull
-    public static Semver withClearedPreReleaseAndBuild(@NotNull final Semver version) {
+    public static Semver withClearedPreReleaseAndBuild(final Semver version) {
         String newVersion = format(Locale.ROOT, FULL_FORMAT, version.getMajor(), version.getMinor(), version.getPatch());
         return new Semver(newVersion);
     }
 
-    @NotNull
     private static String createFullVersion(
-            @NotNull final Semver version,
-            @NotNull final String main,
-            @NotNull final List<@NotNull String> preRelease
+            final Semver version,
+            final String main,
+            final List<String> preRelease
     ) {
         return createFullVersion(main, preRelease, version.getBuild());
     }
 
-    @NotNull
     private static String createFullVersion(
-            @NotNull final String main,
-            @NotNull final List<@NotNull String> preRelease,
-            @NotNull final List<@NotNull String> build
+            final String main,
+            final List<String> preRelease,
+            final List<String> build
     ) {
         StringBuilder stringBuilder = new StringBuilder(main);
 

--- a/src/main/java/org/semver4j/internal/StrictParser.java
+++ b/src/main/java/org/semver4j/internal/StrictParser.java
@@ -1,7 +1,7 @@
 package org.semver4j.internal;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.semver4j.SemverException;
 
 import java.math.BigInteger;
@@ -18,17 +18,15 @@ import static java.util.Collections.emptyList;
 import static java.util.regex.Pattern.compile;
 import static org.semver4j.internal.Tokenizers.STRICT;
 
+@NullMarked
 public class StrictParser {
-    @NotNull
     private static final Pattern pattern = compile(STRICT);
-    @NotNull
     private static final BigInteger maxInt = BigInteger.valueOf(Integer.MAX_VALUE);
 
     private StrictParser() {
     }
 
-    @NotNull
-    public static Version parse(@NotNull final String version) {
+    public static Version parse(final String version) {
         Matcher matcher = pattern.matcher(version);
 
         if (!matcher.matches()) {
@@ -44,7 +42,7 @@ public class StrictParser {
         return new Version(major, minor, patch, preRelease, build);
     }
 
-    private static int parseInt(@NotNull final String maybeInt) {
+    private static int parseInt(final String maybeInt) {
         BigInteger secureNumber = new BigInteger(maybeInt);
         if (maxInt.compareTo(secureNumber) < 0) {
             throw new SemverException(format(Locale.ROOT, "Value [%s] is too big.", maybeInt));
@@ -58,8 +56,7 @@ public class StrictParser {
         return secureNumber.intValue();
     }
 
-    @NotNull
-    private static List<@NotNull String> convertToList(@Nullable final String toList) {
+    private static List<String> convertToList(final @Nullable String toList) {
         return toList == null ? emptyList() : asList(toList.split("\\."));
     }
 
@@ -67,12 +64,10 @@ public class StrictParser {
         private final int major;
         private final int minor;
         private final int patch;
-        @NotNull
-        private final List<@NotNull String> preRelease;
-        @NotNull
-        private final List<@NotNull String> build;
+        private final List<String> preRelease;
+        private final List<String> build;
 
-        Version(final int major, final int minor, final int patch, @NotNull final List<@NotNull String> preRelease, @NotNull final List<@NotNull String> build) {
+        Version(final int major, final int minor, final int patch, final List<String> preRelease, final List<String> build) {
             this.major = major;
             this.minor = minor;
             this.patch = patch;
@@ -96,18 +91,16 @@ public class StrictParser {
             return patch;
         }
 
-        @NotNull
-        public List<@NotNull String> getPreRelease() {
+        public List<String> getPreRelease() {
             return preRelease;
         }
 
-        @NotNull
-        public List<@NotNull String> getBuild() {
+        public List<String> getBuild() {
             return build;
         }
 
         @Override
-        public boolean equals(@Nullable final Object o) {
+        public boolean equals(final @Nullable Object o) {
             if (this == o) {
                 return true;
             }
@@ -130,7 +123,6 @@ public class StrictParser {
         }
 
         @Override
-        @NotNull
         public String toString() {
             return new StringJoiner(", ", Version.class.getSimpleName() + "[", "]")
                 .add("major=" + major)

--- a/src/main/java/org/semver4j/internal/Tokenizers.java
+++ b/src/main/java/org/semver4j/internal/Tokenizers.java
@@ -1,14 +1,14 @@
 package org.semver4j.internal;
 
-import org.jetbrains.annotations.NotNull;
-
 import java.util.Locale;
+import org.jspecify.annotations.NullMarked;
 
 import static java.lang.String.format;
 
 /**
  * List of regexp that helps with tokenizing and parsing <a href="https://semver.org">semver</a> strings.
  */
+@NullMarked
 @SuppressWarnings("checkstyle:DeclarationOrder")
 public class Tokenizers {
     private Tokenizers() {
@@ -18,36 +18,28 @@ public class Tokenizers {
      * Not negative integers without leading zeroes.<br>
      * See <a href="https://semver.org/#spec-item-2">semver.org#spec-item-2</a>
      */
-    @NotNull
     private static final String NUMERIC_IDENTIFIER = "0|[1-9]\\d*";
 
-    @NotNull
     private static final String NON_NUMERIC_IDENTIFIER = "\\d*[a-zA-Z-][a-zA-Z0-9-]*";
 
     /**
      * Dot separated numeric version identifiers (<b>MAJOR</b>.<b>MINOR</b>.<b>PATCH</b>).<br>
      * See <a href="https://semver.org/#summary">semver.org#summary</a>
      */
-    @NotNull
     private static final String MAIN_VERSION = format(Locale.ROOT, "(%s)\\.(%s)\\.(%s)", NUMERIC_IDENTIFIER, NUMERIC_IDENTIFIER, NUMERIC_IDENTIFIER);
 
-    @NotNull
     private static final String PRERELEASE_IDENTIFIER = format(Locale.ROOT, "(?:%s|%s)", NUMERIC_IDENTIFIER, NON_NUMERIC_IDENTIFIER);
 
     /**
      * Prerelease identifier forwarded by hyphen with appended series of dot-separated identifiers.<br>
      * See <a href="https://semver.org/#spec-item-9">semver.org#spec-item-9</a>
      */
-    @NotNull
     private static final String PRERELEASE = format(Locale.ROOT, "(?:-(%s(?:\\.%s)*))", PRERELEASE_IDENTIFIER, PRERELEASE_IDENTIFIER);
 
-    @NotNull
     private static final String BUILD_IDENTIFIER = "[0-9A-Za-z-]+";
 
-    @NotNull
     private static final String BUILD = format(Locale.ROOT, "(?:\\+(%s(?:\\.%s)*))", BUILD_IDENTIFIER, BUILD_IDENTIFIER);
 
-    @NotNull
     private static final String STRICT_PLAIN = format(Locale.ROOT, "v?%s%s?%s?", MAIN_VERSION, PRERELEASE, BUILD);
 
     /**
@@ -62,40 +54,29 @@ public class Tokenizers {
      * X.Y.X-beta.1+sha1234
      * </code>
      */
-    @NotNull
     public static final String STRICT = format(Locale.ROOT, "^%s$", STRICT_PLAIN);
 
     /**
      * <p>{@code x}, {@code X} and {@code *} are for X-Ranges.</p>
      * <p>{@code +} is for Ivy ranges.</p>
      */
-    @NotNull
     private static final String XRANGE_IDENTIFIER = format(Locale.ROOT, "%s|x|X|\\*|\\+", NUMERIC_IDENTIFIER);
 
-    @NotNull
     private static final String XRANGE_PLAIN = format(Locale.ROOT, "[v=\\s]*(%s)(?:\\.(%s)(?:\\.(%s)(?:%s)?%s?)?)?", XRANGE_IDENTIFIER, XRANGE_IDENTIFIER, XRANGE_IDENTIFIER, PRERELEASE, BUILD);
 
-    @NotNull
     private static final String LONE_CARET = "(?:\\^)";
 
-    @NotNull
     public static final String CARET = format(Locale.ROOT, "^%s%s$", LONE_CARET, XRANGE_PLAIN);
 
-    @NotNull
     public static final String HYPHEN = format(Locale.ROOT, "^\\s*(%s)\\s+-\\s+(%s)\\s*$", XRANGE_PLAIN, XRANGE_PLAIN);
 
-    @NotNull
     public static final String IVY = "^(\\[|\\]|\\()([0-9]+)?\\.?([0-9]+)?\\.?([0-9]+)?\\,([0-9]+)?\\.?([0-9]+)?\\.?([0-9]+)?(\\]|\\[|\\))$";
 
-    @NotNull
     public static final String TILDE = format(Locale.ROOT, "^(?:~>?)%s$", XRANGE_PLAIN);
 
-    @NotNull
     private static final String GLTL = "((?:<|>)?=?)";
 
-    @NotNull
     public static final String XRANGE = format(Locale.ROOT, "^%s\\s*%s$", GLTL, XRANGE_PLAIN);
 
-    @NotNull
     public static final String COMPARATOR = format(Locale.ROOT, "^%s\\s*(%s)$|^$", GLTL, STRICT_PLAIN);
 }

--- a/src/main/java/org/semver4j/internal/range/RangeProcessorPipeline.java
+++ b/src/main/java/org/semver4j/internal/range/RangeProcessorPipeline.java
@@ -1,26 +1,24 @@
 package org.semver4j.internal.range;
 
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NullMarked;
 import org.semver4j.internal.range.processor.Processor;
 
 import java.util.ArrayList;
 
+@NullMarked
 public class RangeProcessorPipeline {
-    @NotNull
-    private final ArrayList<@NotNull Processor> processors = new ArrayList<>();
+    private final ArrayList<Processor> processors = new ArrayList<>();
 
-    public RangeProcessorPipeline(@NotNull final Processor currentProcessor) {
+    public RangeProcessorPipeline(final Processor currentProcessor) {
         this.processors.add(currentProcessor);
     }
 
-    @NotNull
-    public RangeProcessorPipeline addProcessor(@NotNull final Processor processor) {
+    public RangeProcessorPipeline addProcessor(final Processor processor) {
         processors.add(processor);
         return this;
     }
 
-    @NotNull
-    public String process(@NotNull final String range) {
+    public String process(final String range) {
         for (Processor processor : processors) {
             String processedRange = processor.tryProcess(range);
             if (processedRange != null) {
@@ -30,8 +28,7 @@ public class RangeProcessorPipeline {
         return range;
     }
 
-    @NotNull
-    public static RangeProcessorPipeline startWith(@NotNull final Processor processor) {
+    public static RangeProcessorPipeline startWith(final Processor processor) {
         return new RangeProcessorPipeline(processor);
     }
 }

--- a/src/main/java/org/semver4j/internal/range/processor/AllVersionsProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/AllVersionsProcessor.java
@@ -1,7 +1,7 @@
 package org.semver4j.internal.range.processor;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.semver4j.Semver;
 
 import java.util.Locale;
@@ -18,9 +18,10 @@ import static org.semver4j.Range.RangeOperator.GTE;
  *     <li>An empty string to {@code ≥0.0.0}</li>
  * </ul>
  */
+@NullMarked
 public class AllVersionsProcessor implements Processor {
     @Override
-    public @Nullable String tryProcess(@NotNull String range) {
+    public @Nullable String tryProcess(String range) {
         if (range.equals("*") || range.isEmpty()) {
             return format(Locale.ROOT, "%s%s", GTE.asString(), Semver.ZERO);
         }

--- a/src/main/java/org/semver4j/internal/range/processor/AllVersionsProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/AllVersionsProcessor.java
@@ -21,7 +21,8 @@ import static org.semver4j.Range.RangeOperator.GTE;
 @NullMarked
 public class AllVersionsProcessor implements Processor {
     @Override
-    public @Nullable String tryProcess(String range) {
+    @Nullable
+    public String tryProcess(String range) {
         if (range.equals("*") || range.isEmpty()) {
             return format(Locale.ROOT, "%s%s", GTE.asString(), Semver.ZERO);
         }

--- a/src/main/java/org/semver4j/internal/range/processor/CaretProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/CaretProcessor.java
@@ -1,7 +1,7 @@
 package org.semver4j.internal.range.processor;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Locale;
 import java.util.regex.Matcher;
@@ -26,12 +26,12 @@ import static org.semver4j.internal.range.processor.RangesUtils.parseIntWithXSup
  *     <li>{@code ^0.2.3} to {@code ≥0.2.3 <0.3.0}</li>
  * </ul>
  */
+@NullMarked
 public class CaretProcessor implements Processor {
-    @NotNull
     private static final Pattern pattern = compile(CARET);
 
     @Override
-    public @Nullable String tryProcess(@NotNull String range) {
+    public @Nullable String tryProcess(String range) {
         Matcher matcher = pattern.matcher(range);
 
         if (!matcher.matches()) {

--- a/src/main/java/org/semver4j/internal/range/processor/GreaterThanOrEqualZeroProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/GreaterThanOrEqualZeroProcessor.java
@@ -1,7 +1,7 @@
 package org.semver4j.internal.range.processor;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.semver4j.Semver;
 
 import java.util.Locale;
@@ -19,10 +19,11 @@ import static org.semver4j.Range.RangeOperator.GTE;
  *
  * @deprecated behavior has been split off into {@link AllVersionsProcessor} and {@link IvyProcessor}
  */
+@NullMarked
 @Deprecated
 public class GreaterThanOrEqualZeroProcessor implements Processor {
     @Override
-    public @Nullable String tryProcess(@NotNull String range) {
+    public @Nullable String tryProcess(String range) {
         if (range.equals("latest") || range.equals("latest.integration") || range.equals("*") || range.isEmpty()) {
             return format(Locale.ROOT, "%s%s", GTE.asString(), Semver.ZERO);
         }

--- a/src/main/java/org/semver4j/internal/range/processor/GreaterThanOrEqualZeroProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/GreaterThanOrEqualZeroProcessor.java
@@ -23,7 +23,8 @@ import static org.semver4j.Range.RangeOperator.GTE;
 @Deprecated
 public class GreaterThanOrEqualZeroProcessor implements Processor {
     @Override
-    public @Nullable String tryProcess(String range) {
+    @Nullable
+    public String tryProcess(String range) {
         if (range.equals("latest") || range.equals("latest.integration") || range.equals("*") || range.isEmpty()) {
             return format(Locale.ROOT, "%s%s", GTE.asString(), Semver.ZERO);
         }

--- a/src/main/java/org/semver4j/internal/range/processor/HyphenProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/HyphenProcessor.java
@@ -33,7 +33,8 @@ public class HyphenProcessor implements Processor {
     private static final Pattern pattern = compile(HYPHEN);
 
     @Override
-    public @Nullable String tryProcess(String range) {
+    @Nullable
+    public String tryProcess(String range) {
         Matcher matcher = pattern.matcher(range);
 
         if (!matcher.matches()) {

--- a/src/main/java/org/semver4j/internal/range/processor/HyphenProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/HyphenProcessor.java
@@ -1,7 +1,7 @@
 package org.semver4j.internal.range.processor;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Locale;
 import java.util.regex.Matcher;
@@ -28,12 +28,12 @@ import static org.semver4j.internal.range.processor.RangesUtils.parseIntWithXSup
  *     <li>{@code 1.2.3 - 2} to {@code ≥1.2.3 <3.0.0}</li>
  * </ul>
  */
+@NullMarked
 public class HyphenProcessor implements Processor {
-    @NotNull
     private static final Pattern pattern = compile(HYPHEN);
 
     @Override
-    public @Nullable String tryProcess(@NotNull String range) {
+    public @Nullable String tryProcess(String range) {
         Matcher matcher = pattern.matcher(range);
 
         if (!matcher.matches()) {
@@ -46,8 +46,7 @@ public class HyphenProcessor implements Processor {
         return format(Locale.ROOT, "%s %s", rangeFrom, rangeTo);
     }
 
-    @NotNull
-    private String getRangeFrom(@NotNull final Matcher matcher) {
+    private String getRangeFrom(final Matcher matcher) {
         String from = matcher.group(1);
 
         int fromMajor = parseIntWithXSupport(matcher.group(2));
@@ -68,8 +67,7 @@ public class HyphenProcessor implements Processor {
         }
     }
 
-    @NotNull
-    private String getRangeTo(@NotNull final Matcher matcher) {
+    private String getRangeTo(final Matcher matcher) {
         String to = matcher.group(7);
 
         int toMajor = parseIntWithXSupport(matcher.group(8));

--- a/src/main/java/org/semver4j/internal/range/processor/IvyProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/IvyProcessor.java
@@ -45,7 +45,8 @@ public class IvyProcessor implements Processor {
     private static final Pattern PATTERN = compile(IVY);
 
     @Override
-    public @Nullable String tryProcess(String range) {
+    @Nullable
+    public String tryProcess(String range) {
         if (range.equals(LATEST) || range.equals(LATEST_INTEGRATION)) {
             return ALL_RANGE;
         }

--- a/src/main/java/org/semver4j/internal/range/processor/IvyProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/IvyProcessor.java
@@ -1,7 +1,7 @@
 package org.semver4j.internal.range.processor;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Locale;
 import java.util.regex.Matcher;
@@ -37,15 +37,15 @@ import static org.semver4j.internal.range.processor.RangesUtils.parseIntWithXSup
  *     <li>{@code latest.integration} to {@code ≥0.0.0}</li>
  * </ul>
  */
+@NullMarked
 public class IvyProcessor implements Processor {
     private static final String LATEST = "latest";
     private static final String LATEST_INTEGRATION = LATEST + ".integration";
 
-    @NotNull
     private static final Pattern PATTERN = compile(IVY);
 
     @Override
-    public @Nullable String tryProcess(@NotNull String range) {
+    public @Nullable String tryProcess(String range) {
         if (range.equals(LATEST) || range.equals(LATEST_INTEGRATION)) {
             return ALL_RANGE;
         }
@@ -110,7 +110,7 @@ public class IvyProcessor implements Processor {
         return range;
     }
 
-    private boolean isInclusiveRange(@NotNull final String character) {
+    private boolean isInclusiveRange(final String character) {
         return character.equals("[") || character.equals("]");
     }
 }

--- a/src/main/java/org/semver4j/internal/range/processor/Processor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/Processor.java
@@ -1,20 +1,19 @@
 package org.semver4j.internal.range.processor;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
 import java.util.Optional;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Processor for pipeline range translations.
  */
+@NullMarked
 public interface Processor {
     @Deprecated
-    @NotNull
-    default String process(@NotNull String range) {
+    default String process(String range) {
         return Optional.ofNullable(tryProcess(range)).orElse(range);
-    };
+    }
 
     @Nullable
-    String tryProcess(@NotNull String range);
+    String tryProcess(String range);
 }

--- a/src/main/java/org/semver4j/internal/range/processor/RangesUtils.java
+++ b/src/main/java/org/semver4j/internal/range/processor/RangesUtils.java
@@ -1,7 +1,7 @@
 package org.semver4j.internal.range.processor;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.semver4j.Semver;
 
 import java.util.Locale;
@@ -13,12 +13,10 @@ import static org.semver4j.Range.RangeOperator.GTE;
 /**
  * Set of methods which helps ranges handling.
  */
+@NullMarked
 final class RangesUtils {
-    @NotNull
     static final String EMPTY = "";
-    @NotNull
     static final String SPACE = " ";
-    @NotNull
     static final String ALL_RANGE = format(Locale.ROOT, "%s%s", GTE.asString(), Semver.ZERO);
 
     private static final int X_RANGE_MARKER = -1;
@@ -26,7 +24,7 @@ final class RangesUtils {
     private RangesUtils() {
     }
 
-    static int parseIntWithXSupport(@Nullable final String id) {
+    static int parseIntWithXSupport(final @Nullable String id) {
         if (id == null || id.equalsIgnoreCase("x") || id.equals("*") || id.equals("+")) {
             return X_RANGE_MARKER;
         }
@@ -37,7 +35,7 @@ final class RangesUtils {
         return id == X_RANGE_MARKER;
     }
 
-    static boolean isNotBlank(@Nullable final String id) {
+    static boolean isNotBlank(final @Nullable String id) {
         return id != null && !id.isEmpty();
     }
 }

--- a/src/main/java/org/semver4j/internal/range/processor/TildeProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/TildeProcessor.java
@@ -35,7 +35,8 @@ public class TildeProcessor implements Processor {
     private static final Pattern pattern = compile(TILDE);
 
     @Override
-    public @Nullable String tryProcess(String range) {
+    @Nullable
+    public String tryProcess(String range) {
         Matcher matcher = pattern.matcher(range);
 
         if (!matcher.matches()) {

--- a/src/main/java/org/semver4j/internal/range/processor/TildeProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/TildeProcessor.java
@@ -1,7 +1,7 @@
 package org.semver4j.internal.range.processor;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Locale;
 import java.util.regex.Matcher;
@@ -30,12 +30,12 @@ import static org.semver4j.internal.range.processor.RangesUtils.parseIntWithXSup
  *     <li>{@code ~0} to {@code ≥0.0.0 <1.0.0}</li>
  * </ul>
  */
+@NullMarked
 public class TildeProcessor implements Processor {
-    @NotNull
     private static final Pattern pattern = compile(TILDE);
 
     @Override
-    public @Nullable String tryProcess(@NotNull String range) {
+    public @Nullable String tryProcess(String range) {
         Matcher matcher = pattern.matcher(range);
 
         if (!matcher.matches()) {

--- a/src/main/java/org/semver4j/internal/range/processor/XRangeProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/XRangeProcessor.java
@@ -33,7 +33,8 @@ public class XRangeProcessor implements Processor {
     private static final Pattern pattern = compile(XRANGE);
 
     @Override
-    public @Nullable String tryProcess(String range) {
+    @Nullable
+    public String tryProcess(String range) {
         String[] rangeVersions = range.split("\\s+");
 
         List<String> objects = new ArrayList<>();

--- a/src/main/java/org/semver4j/internal/range/processor/XRangeProcessor.java
+++ b/src/main/java/org/semver4j/internal/range/processor/XRangeProcessor.java
@@ -1,7 +1,7 @@
 package org.semver4j.internal.range.processor;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,12 +28,12 @@ import static org.semver4j.internal.range.processor.RangesUtils.parseIntWithXSup
  * range.</p>
  * <br>
  */
+@NullMarked
 public class XRangeProcessor implements Processor {
-    @NotNull
     private static final Pattern pattern = compile(XRANGE);
 
     @Override
-    public @Nullable String tryProcess(@NotNull String range) {
+    public @Nullable String tryProcess(String range) {
         String[] rangeVersions = range.split("\\s+");
 
         List<String> objects = new ArrayList<>();

--- a/src/test/java/org/semver4j/internal/range/processor/ProcessorTest.java
+++ b/src/test/java/org/semver4j/internal/range/processor/ProcessorTest.java
@@ -1,7 +1,6 @@
 package org.semver4j.internal.range.processor;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -12,7 +11,7 @@ class ProcessorTest {
     void nonNullProcessGetsReturned() {
         Processor nonNullResultProcessor = new Processor() {
             @Override
-            public @NotNull String tryProcess(@NotNull String range) {
+            public @Nullable String tryProcess(String range) {
                 return "RESULT";
             }
         };
@@ -24,7 +23,7 @@ class ProcessorTest {
     void nullProcessDoesNotGetReturned() {
         Processor nullResultProcessor = new Processor() {
             @Override
-            public @Nullable String tryProcess(@NotNull String range) {
+            public @Nullable String tryProcess(String range) {
                 return null;
             }
         };

--- a/src/test/java/org/semver4j/internal/range/processor/ProcessorTest.java
+++ b/src/test/java/org/semver4j/internal/range/processor/ProcessorTest.java
@@ -11,7 +11,8 @@ class ProcessorTest {
     void nonNullProcessGetsReturned() {
         Processor nonNullResultProcessor = new Processor() {
             @Override
-            public @Nullable String tryProcess(String range) {
+            @Nullable
+            public String tryProcess(String range) {
                 return "RESULT";
             }
         };
@@ -23,7 +24,8 @@ class ProcessorTest {
     void nullProcessDoesNotGetReturned() {
         Processor nullResultProcessor = new Processor() {
             @Override
-            public @Nullable String tryProcess(String range) {
+            @Nullable
+            public String tryProcess(String range) {
                 return null;
             }
         };


### PR DESCRIPTION
Replace nullness annotations with JSpecify.
Related issue #308 

Changes in this PR:

- pom.xml: `org.jetbrains:annotations` replaced with `org.jspecify:jspecify` ([docs](https://jspecify.dev/docs/using/#depending-on-the-annotations))
- Replace `@NonNull` annotations with `@NullMarked` annotation - to mark all types in the class scope as non-null by default ([docs](https://jspecify.dev/docs/user-guide/#nullmarked))
- Move `@Nullable` annotations to types
  - `@Nullable public static Semver` -> `public static @Nullable Semver`
  - `@Nullable final String version` -> `final @Nullable String version`
- Removed single use of the `org.jetbrains.annotations.ApiStatus.AvailableSince` annotation - we have same info in the JavaDoc `@since` tag
- Fixed invalid annotation in the `src/test/java/org/semver4j/internal/range/processor/ProcessorTest.java` file (when we implement an interface, we should keep the same type annotations)