### PR TITLE
make `Semver` `Serializable`

### DIFF
--- a/src/main/java/org/semver4j/Semver.java
+++ b/src/main/java/org/semver4j/Semver.java
@@ -5,6 +5,8 @@ import static java.util.Collections.emptyList;
 import static java.util.Objects.hash;
 import static java.util.Objects.requireNonNull;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
@@ -23,7 +25,10 @@ import org.semver4j.range.RangeListFactory;
  * <p>This implementation adheres to the SemVer 2.0.0 specification and provides a comprehensive API for version
  * parsing, comparison, manipulation, and validation.
  */
-public class Semver implements Comparable<Semver> {
+public class Semver implements Comparable<Semver>, Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     /** A constant {@link Semver} version object representing {@code 0.0.0}. */
     public static final Semver ZERO = new Semver("0.0.0");
 

--- a/src/test/java/org/semver4j/SemverTest.java
+++ b/src/test/java/org/semver4j/SemverTest.java
@@ -12,6 +12,10 @@ import static org.semver4j.Semver.VersionDiff.*;
 import static org.semver4j.Semver.coerce;
 import static org.semver4j.Semver.isValid;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Stream;
@@ -1353,5 +1357,24 @@ class SemverTest {
 
         // then
         assertThat(version).isEqualTo("1:2:3|alpha*5bb76cdb");
+    }
+
+    @Test
+    void shouldSerializeAndDeserialize() throws Exception {
+        // given
+        Semver semver = Semver.create(1, 2, 3);
+
+        // when
+        final var serialized = new ByteArrayOutputStream();
+        try (final var oos = new ObjectOutputStream(serialized)) {
+            oos.writeObject(semver);
+        }
+        final Semver deserializedSemver;
+        try (final var ois = new ObjectInputStream(new ByteArrayInputStream(serialized.toByteArray()))) {
+            deserializedSemver = (Semver) ois.readObject();
+        }
+
+        // then
+        assertThat(deserializedSemver).isNotSameAs(semver).isEqualTo(semver);
     }
 }


### PR DESCRIPTION
this allows passing `Semver` around through libraries which serialize it or storing it in files.

the current workaround is to use a `String` representation for (de)serialization and convert to/from a `Semver`.